### PR TITLE
Install and Configure User Abilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@
 /config/master.key
 
 # Ignore coverage folder
-/coverage
+/coverage/*

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ gem 'bootstrap', '~> 4.3.1'
 gem 'jquery-rails'
 # Use dotenv gem to store the environment variables
 gem 'dotenv-rails'
+# Use petergate gem for authorization
+gem 'petergate'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -154,6 +154,8 @@ GEM
     parallel (1.18.0)
     parser (2.6.5.0)
       ast (~> 2.4.0)
+    petergate (2.0.1)
+      activerecord (> 4.0.0)
     popper_js (1.14.5)
     public_suffix (4.0.1)
     puma (3.12.1)
@@ -315,6 +317,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  petergate
   puma (~> 3.11)
   rails (~> 5.2.3)
   rails-controller-testing

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,14 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  ############################################################################################
+  ## PeterGate Roles                                                                        ##
+  ## The :user role is added by default and shouldn't be included in this list.             ##
+  ## The :root_admin can access any page regardless of access settings. Use with caution!   ##
+  ## The multiple option can be set to true if you need users to have multiple roles.       ##
+  petergate(roles: %i[admin editor], multiple: false) ##
+  ############################################################################################
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/db/migrate/20191115182124_add_roles_to_users.rb
+++ b/db/migrate/20191115182124_add_roles_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Add 'roles' column to users table
+class AddRolesToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :roles, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_191_018_163_508) do
+ActiveRecord::Schema.define(version: 20_191_115_182_124) do
   create_table 'users', force: :cascade do |t|
     t.string 'email', default: '', null: false
     t.string 'encrypted_password', default: '', null: false
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 20_191_018_163_508) do
     t.datetime 'remember_created_at'
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
+    t.string 'roles'
     t.index ['email'], name: 'index_users_on_email', unique: true
     t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
   end


### PR DESCRIPTION
Fixes #21 

1) Enabled authorization for users by installing "Petergate" gem (https://github.com/elorest/petergate)
2) Petergate gem has default ":user" role which can be used as "viewer" role. So, added only admin and editor.