### PR TITLE
Create Software Record as Unauthenticated User

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -51,4 +51,4 @@ Metrics/BlockLength:
   Max: 154
 
 Metrics/LineLength:
-  Max: 230
+  Max: 260

--- a/app/assets/javascripts/request_software_controller.coffee
+++ b/app/assets/javascripts/request_software_controller.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/javascripts/request_softwares.coffee
+++ b/app/assets/javascripts/request_softwares.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -229,3 +229,7 @@ a:hover {
 .labels {
   font-size: 14px
 }
+
+.dashboard-actions {
+  padding: 12px
+}

--- a/app/assets/stylesheets/request_software_controller.scss
+++ b/app/assets/stylesheets/request_software_controller.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the RequestSoftwareController controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/request_softwares.scss
+++ b/app/assets/stylesheets/request_softwares.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the RequestSoftwares controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/software_records.scss
+++ b/app/assets/stylesheets/software_records.scss
@@ -301,7 +301,9 @@ dt{
   padding-left: 8px;
 }
 
-
+select#software_record_status {
+  
+}
 
 @media screen and (max-height: 450px) {
   .sidenav {padding-top: 15px;}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,6 +3,7 @@
 # Application Controller
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  helper_method :current_or_guest_user
   # Redirect to dashboard on user login
   def after_sign_in_path_for(_resource)
     # return the path based on resource

--- a/app/controllers/front_controller.rb
+++ b/app/controllers/front_controller.rb
@@ -3,18 +3,27 @@
 class FrontController < ApplicationController
   layout 'application'
   before_action :authenticate_user!, only: %i[dashboard profile]
+
   def index
     $page_title = 'Welcome | Application Portfolio'
     @controller = params[:controller]
-    render 'index'
   end
 
   def dashboard
     $page_title = 'Dashboard | Application Portfolio'
-    @softwarerecords_indesign = SoftwareRecordsController.indesign_dashboard
-    @indesign_count = @softwarerecords_indesign.count
-    @softwarerecords_production = SoftwareRecordsController.production_dashboard
-    @production_count = @softwarerecords_production.count
+    @user = current_user.first_name + ' ' + current_user.last_name
+    @softwarerecords_indesign = SoftwareRecordsController.indesign_dashboard(@user)
+    begin
+      @indesign_count = @softwarerecords_indesign.count
+    rescue StandardError
+      @indesign_count = 0
+    end
+    @softwarerecords_production = SoftwareRecordsController.production_dashboard(@user)
+    begin
+      @production_count = @softwarerecords_production.count
+    rescue StandardError
+      @production_count = 0
+    end
     render 'dashboard'
   end
 
@@ -31,5 +40,19 @@ class FrontController < ApplicationController
   def profile
     $page_title = 'My Profile | Application Portfolio'
     render 'profile'
+  end
+
+  def new
+    $page_title = 'Request Software | Application Portfolio'
+    @requestsoftwaress = SoftwareRecord.new
+  end
+
+  def create
+    @requestsoftwaress = SoftwareRecord.new(params.require(:software_record).permit(:title, :description, :status, :created_by, :tentative_date_of_implementation, :notes, :departments, :product_owners, :software_type_id, :vendor_recor_id))
+    if @requestsoftwaress.save
+      redirect_to @request_softwares, notice: 'Software record was successfully requested.'
+    else
+      render :new
+    end
   end
 end

--- a/app/controllers/request_software_mailer_controller.rb
+++ b/app/controllers/request_software_mailer_controller.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Software Request mailer
+class RequestSoftwareMailerController < ActionMailer::Base
+  def send_mail
+    default from: 'uclappdev@uc.edu'
+
+    mail(
+      to: 'mallepvl@mail.uc.edu',
+      subject: 'Welcome'
+    )
+  end
+end

--- a/app/controllers/software_records_controller.rb
+++ b/app/controllers/software_records_controller.rb
@@ -4,23 +4,37 @@
 class SoftwareRecordsController < ApplicationController
   layout 'software_records'
   include SoftwareRecordsHelper
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: %i[new create show]
   before_action :set_software_record, only: %i[show edit update destroy]
-  access all: %i[index show new edit create update destroy], user: :all
+  access all: %i[create show], viewer: %i[index show], owner: %i[index show edit update], manager: %i[index show edit update new create destroy], admin: :all
   # GET /software_records
-
   $page_title = 'Software Records | Application Portfolio'
+
   def index
     @softwarerecords_count = SoftwareRecord.count
     @software_records = SoftwareRecord.order(sort_column + ' ' + sort_direction)
   end
 
-  def self.indesign_dashboard
-    SoftwareRecord.where(status: 'In Design').or(SoftwareRecord.where(status: 'In Development'))
+  def self.indesign_dashboard(user)
+    indesign_filter = SoftwareRecord.where(status: 'In Design')
+    indev_filter = SoftwareRecord.where(status: 'In Development')
+    user_filter = SoftwareRecord.where("created_by like '%#{user}%'")
+    developer_filter = SoftwareRecord.where("developers like '%#{user}%'")
+    tech_leads_filter = SoftwareRecord.where("tech_leads like '%#{user}%'")
+    product_owners_filter = SoftwareRecord.where("product_owners like '%#{user}%'")
+    currentuser_filter = user_filter.or(developer_filter).or(tech_leads_filter).or(product_owners_filter)
+    dashboard_filter = indesign_filter.or(indev_filter)
+    dashboard_filter.merge(currentuser_filter)
   end
 
-  def self.production_dashboard
-    SoftwareRecord.where(status: 'Production')
+  def self.production_dashboard(user)
+    production_filter = SoftwareRecord.where(status: 'Production')
+    user_filter = SoftwareRecord.where(created_by: user)
+    developer_filter = SoftwareRecord.where("developers like '%#{user}%'")
+    tech_leads_filter = SoftwareRecord.where("tech_leads like '%#{user}%'")
+    product_owners_filter = SoftwareRecord.where("product_owners like '%#{user}%'")
+    currentuser_filter = user_filter.or(developer_filter).or(tech_leads_filter).or(product_owners_filter)
+    production_filter.merge(currentuser_filter)
   end
 
   # GET /software_records/1
@@ -38,8 +52,11 @@ class SoftwareRecordsController < ApplicationController
   def create
     @software_record = SoftwareRecord.new(software_record_params)
 
-    if @software_record.save
+    if @software_record.save && user_signed_in?
       redirect_to @software_record, notice: 'Software record was successfully created.'
+    elsif !user_signed_in? && @software_record.save
+      redirect_to @software_record, notice: 'Software record was successfully requested.'
+      RequestSoftwareMailerController.send_mail
     else
       render :new
     end
@@ -90,7 +107,9 @@ class SoftwareRecordsController < ApplicationController
       :current_version,
       :notes,
       :business_value,
-      :it_quality
+      :it_quality,
+      :created_by,
+      :tentative_date_implemented
     )
   end
 end

--- a/app/controllers/software_types_controller.rb
+++ b/app/controllers/software_types_controller.rb
@@ -6,7 +6,8 @@ class SoftwareTypesController < ApplicationController
   before_action :authenticate_user!
   include SoftwareTypesHelper
   before_action :set_software_type, only: %i[show edit update destroy]
-  access all: %i[index show new edit create update destroy], user: :all
+  # access all: %i[index show new edit create update destroy], user: :all
+  access viewer: %i[index show], owner: %i[index show edit update], manager: %i[index show edit update new create destroy], admin: :all
   $page_title = 'Software Types | Application Portfolio'
   # GET /software_types
   def index

--- a/app/controllers/vendor_records_controller.rb
+++ b/app/controllers/vendor_records_controller.rb
@@ -6,8 +6,8 @@ class VendorRecordsController < ApplicationController
   include VendorRecordsHelper
   before_action :authenticate_user!
   before_action :set_vendor_record, only: %i[show edit update destroy]
-  access all: %i[index show new edit create update destroy], user: :all
-
+  # access all: %i[index show new edit create update destroy], user: :all
+  access viewer: %i[index show], owner: %i[index show edit update], manager: %i[index show edit update new create destroy], admin: :all
   $page_title = 'Vendor Records | Application Portfolio'
   # GET /vendor_records
   def index

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -31,7 +31,8 @@ module ApplicationHelper
         (link_to 'About', about_path, class: "#{style} #{active? about_path}") + ' '.html_safe +
         (link_to 'Contact', contact_path, class: "#{style} #{active? contact_path}")
     else
-      (link_to 'Login', new_user_session_path, class: "#{style} #{active? new_user_session_path}") + ' '.html_safe +
+      (link_to 'Request Software', request_new_path, class: "#{style} #{active? request_new_path}") + ' '.html_safe +
+        (link_to 'Login', new_user_session_path, class: "#{style} #{active? new_user_session_path}") + ' '.html_safe +
         (link_to 'About', about_path, class: "#{style} #{active? about_path}") + ' '.html_safe +
         (link_to 'Contact', contact_path, class: "#{style} #{active? contact_path}")
     end

--- a/app/models/software_record.rb
+++ b/app/models/software_record.rb
@@ -2,8 +2,8 @@
 
 # SoftwareRecord Model
 class SoftwareRecord < ApplicationRecord
-  STATUSES = ['None', 'In Design', 'In Development', 'Production', 'Available', 'To be decomissioned'].freeze
+  STATUSES = ['None', 'In Design', 'In Development', 'Production', 'Available', 'To be decomissioned', 'Requested'].freeze
   belongs_to :software_type
   belongs_to :vendor_record
-  validates_presence_of :title, :description, :status
+  validates_presence_of :title, :description, :status, :created_by
 end

--- a/app/models/software_type.rb
+++ b/app/models/software_type.rb
@@ -4,4 +4,5 @@
 class SoftwareType < ApplicationRecord
   validates_presence_of :title, :description
   has_many :software_records
+  has_many :request_softwares
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,7 +6,7 @@ class User < ApplicationRecord
   ## The :user role is added by default and shouldn't be included in this list.             ##
   ## The :root_admin can access any page regardless of access settings. Use with caution!   ##
   ## The multiple option can be set to true if you need users to have multiple roles.       ##
-  petergate(roles: %i[admin editor], multiple: false) ##
+  petergate(roles: %i[admin owner viewer manager], multiple: false) ##
   ############################################################################################
   validates_presence_of :first_name, :last_name, :email
   # Include default devise modules. Others available are:

--- a/app/models/vendor_record.rb
+++ b/app/models/vendor_record.rb
@@ -4,4 +4,5 @@
 class VendorRecord < ApplicationRecord
   validates_presence_of :title, :description
   has_many :software_records
+  has_many :request_softwares
 end

--- a/app/views/front/dashboard.html.erb
+++ b/app/views/front/dashboard.html.erb
@@ -2,7 +2,7 @@
   <div class="card-deck mb-3 text-center" style="color: black;">
     <div class="card mb-4 box-shadow animated fadeInLeft" style="width: 33.33%; height: auto;">
       <div class="card-header">
-        <h3 class="my-0 font-weight-normal text-uppercase" style="font-size: 21px;">Software Records In-Design/Development</h3>
+        <h3 class="my-0 font-weight-normal text-uppercase" style="font-size: 21px;">My Software Records In-Design/Development</h3>
       </div>
       <div class="card-body">
         <% if @indesign_count != 0 %>
@@ -12,7 +12,13 @@
                 <th>Software Records</th>
                 <th>Created on</th>
                 <th>Status</th>
-                <th>Action</th>
+                <% if current_user.role.to_s == "viewer" %>
+                  <th>Action</th>
+                <% elsif current_user.role.to_s == "owner" %>
+                  <th colspan="2">Actions</th>
+                <% else %>
+                  <th colspan="3">Actions</th>
+                <% end %>
               </tr>
             </thead>
             <tbody>
@@ -21,7 +27,16 @@
                   <td><%= record_indesign.title %></td>
                   <td><%= record_indesign.created_at.to_date %></td>
                   <td style="font-size: 12px"><%= pills record_indesign.status %></td>
-                  <td><%= link_to 'View', record_indesign , { :class => "btn btn-success" }%></td>
+                  <% if current_user.role.to_s == "viewer" %>
+                    <td><%= link_to 'View', record_indesign , { :class => "btn btn-success" }%></td>
+                  <% elsif current_user.role.to_s == "owner" %>
+                    <td><%= link_to 'View', record_indesign , { :class => "btn btn-success", :style => "font-size: 15px" }%></td>
+                    <td><%= link_to 'Edit', edit_software_record_path(record_indesign) , { :class => "btn btn-primary", :style => "font-size: 15px" }%></td>
+                  <% else %>
+                    <td><%= link_to 'View', record_indesign , { :class => "btn btn-success", :style => "font-size: 15px" }%></td>
+                    <td><%= link_to 'Edit', edit_software_record_path(record_indesign) , { :class => "btn btn-primary", :style => "font-size: 15px" }%></td>
+                    <td><%= link_to 'Delete', record_indesign, method: :delete, :class => "btn btn-danger", :style => "font-size: 15px", data: { confirm: 'Are you sure?' } %></td>
+                  <% end %>
                 </tr>
               <% end %>
             </tbody>
@@ -32,9 +47,11 @@
         <br/>
       </div>
     </div>
+  </div>
+  <div class="card-deck mb-3 text-center" style="color: black;">
     <div class="card mb-4 box-shadow animated fadeInRight" style="width: 33.33%; height: auto;">
       <div class="card-header">
-        <h3 class="my-0 font-weight-normal text-uppercase" style="font-size: 25px">Software Records in Production</h3>
+        <h3 class="my-0 font-weight-normal text-uppercase" style="font-size: 25px">My Software Records In Production</h3>
       </div>
       <div class="card-body">
         <% if @production_count != 0 %>
@@ -43,7 +60,13 @@
             <tr>
               <th>Software Records</th>
               <th>Created on</th>
-              <th>Action</th>
+              <% if current_user.role.to_s == "viewer" %>
+                  <th>Action</th>
+                <% elsif current_user.role.to_s == "owner" %>
+                  <th colspan="2">Actions</th>
+                <% else %>
+                  <th colspan="3">Actions</th>
+                <% end %>
             </tr>
           </thead>
 
@@ -52,7 +75,16 @@
               <tr>
                 <td><%= record_production.title %></td>
                 <td><%= record_production.created_at.to_date %></td>
-                <td><%= link_to 'View', record_production , { :class => "btn btn-success" }%></td>
+                <% if current_user.role.to_s == "viewer" %>
+                    <td><%= link_to 'View', record_production , { :class => "btn btn-success" }%></td>
+                  <% elsif current_user.role.to_s == "owner" %>
+                    <td><%= link_to 'View', record_production , { :class => "btn btn-success", :style => "font-size: 15px" }%></td>
+                    <td><%= link_to 'Edit', edit_software_record_path(record_production) , { :class => "btn btn-primary", :style => "font-size: 15px" }%></td>
+                  <% else %>
+                    <td><%= link_to 'View', record_production , { :class => "btn btn-success", :style => "font-size: 15px" }%></td>
+                    <td><%= link_to 'Edit', edit_software_record_path(record_production) , { :class => "btn btn-primary", :style => "font-size: 15px" }%></td>
+                    <td><%= link_to 'Delete', record_production, method: :delete, :class => "btn btn-danger", :style => "font-size: 15px", data: { confirm: 'Are you sure?' } %></td>
+                  <% end %>
               </tr>
             <% end %>
           </tbody>
@@ -81,7 +113,7 @@
       </div>
       <div class="card-body">
         <%= pie_chart SoftwareRecord.group(:status).count, messages: {empty: "No data"}, download: {filename: "SoftwareRecords"}, dataset: {borderWidth: 3, borderColor: "transparent"}, legend: "bottom", refresh: 60%><br/>
-        <button type="button" class="btn btn-lg btn-block btn-outline-primary">View</button>
+        <button type="button" class="btn btn-lg btn-block btn-outline-primary" onclick = "location.href='/software_records'">View</button>
       </div>
     </div>
     <div class="card mb-4 box-shadow animated fadeInUp" style="width: 33.33%; height: auto">
@@ -90,7 +122,7 @@
       </div>
       <div class="card-body">
         <%= pie_chart VendorRecord.group(:title).count, messages: {empty: "No data"}, download: {filename: "VendorRecords"}, dataset: {borderWidth: 3, borderColor: "transparent"}, legend: "bottom"%><br/>
-        <button type="button" class="btn btn-lg btn-block btn-outline-primary">View</button>
+        <button type="button" class="btn btn-lg btn-block btn-outline-primary" onclick = "location.href='/vendor_records'">View</button>
       </div>
     </div>
   </div>
@@ -98,12 +130,13 @@
   <div class="card-deck mb-3 text-center" style="color: black">
     <div class="card mb-4 box-shadow animated fadeInDown" style="width: 50.33%; height: auto">
       <div class="card-header">
-        <h3 class="my-0 font-weight-normal text-uppercase">Software Types</h3>
+        <h3 class="my-0 font-weight-normal text-uppercase">Software Records</h3>
       </div>
       <div class="card-body">
-        <%= column_chart SoftwareType.group_by_month(:created_at, format: "%b %Y").count, messages: {empty: "No data"}, download: {filename: "SoftwareTypes"}, dataset: {borderWidth: 3, borderColor: "transparent"} %><br/>
+        <%= line_chart SoftwareRecord.group(:status).group_by_week(:created_at).count, legend: "bottom" %> <br/>
+        <!-- <%= column_chart SoftwareType.group_by_month(:created_at, format: "%b %Y").count, messages: {empty: "No data"}, download: {filename: "SoftwareTypes"}, dataset: {borderWidth: 3, borderColor: "transparent"} %><br/> -->
         <!--<%= line_chart SoftwareType.group_by_day(:created_at).count %><br/> -->
-        <button type="button" class="btn btn-lg btn-block btn-outline-primary">View</button>
+        <button type="button" class="btn btn-lg btn-block btn-outline-primary" onclick = "location.href='/software_records'">View</button>
       </div>
     </div>
   </div>

--- a/app/views/front/new.html.erb
+++ b/app/views/front/new.html.erb
@@ -1,0 +1,68 @@
+<div class="container animated fadeIn" style="opacity: 0.8">
+  <div class = "card-detail" style = "background-color: black; width: 100%;"><br/>
+    <h1 class= "text-center" style="color: white;">Request Software Record</h1>
+    <div class = "card-body">
+        <%= form_for(SoftwareRecord.new) do |form| %>
+          
+          <div class="form-group">
+            <%= form.label :title %>
+            <%= form.text_field :title, :class => "form-control" %>
+          </div>
+          
+          <div class="form-group">
+            <%= form.label :description %>
+            <%= form.text_area :description, :class => "form-control" %>
+          </div>
+          
+          <div class="form-group">
+            <%= form.label :status %>
+            <%= form.select :status, options_for_select(['Requested'], :selected=>"Requested"), {}, {:class => "form-control"} %>
+          </div>
+
+          <div class="form-group">
+              <%= form.label :tentative_date_implemented %>
+              <%= form.date_field :tentative_date_implemented, as: :date, value: form.object.try(:strftime,"%m/%d/%Y"), class: 'form-control', required: true %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label "Request By" %>
+            <%= form.text_field :created_by, :class => "form-control regex-createdby", placeholder: "John Doe (FirstName LastName)" %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label "Software Type" %>
+            <%= form.collection_select(:software_type_id, SoftwareType.all, :id, :title, {}, {:class => "form-control"}) %>
+          </div>
+          
+          <div class="form-group">
+            <%= form.label "Vendor" %>
+            <%= form.collection_select(:vendor_record_id, VendorRecord.all, :id, :title, {}, {:class => "form-control"}) %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :departments %>
+            <%= form.text_field :departments, :class => "form-control regex-departments" %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :product_owners %>
+            <%= form.text_field :product_owners, :class => "form-control regex-owners" %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :notes %>
+            <%= form.text_field :notes, :class => "form-control" %>
+          </div>
+        
+        <br/>
+        <div class="form-group" style= "text-align: center;">
+          <%= form.submit nil, class: "btn btn-primary" %>
+            <%= link_to 'Back', software_records_path, :class => "btn btn-warning" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+  <br/>
+  <br/>
+  <br/>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,6 +49,27 @@
     }
     });
   }
+
+  var createdbyfield = document.getElementsByClassName('regex-createdby')[0];
+        createdbyfield.onkeyup = function() {
+            createdbyfield.value = createdbyfield.value.replace(/[^a-zA-Z0-9 ]/, '');
+        }
+  var developerfield = document.getElementsByClassName('regex-developers')[0];
+        developerfield.onkeyup = function() {
+            developerfield.value = developerfield.value.replace(/[^a-zA-Z0-9 ]/, '');
+        }
+  var departmentfield = document.getElementsByClassName('regex-departments')[0];
+        departmentfield.onkeyup = function() {
+            departmentfield.value = departmentfield.value.replace(/[^a-zA-Z0-9 ]/, '');
+        }
+  var leadsfield = document.getElementsByClassName('regex-leads')[0];
+        leadsfield.onkeyup = function() {
+            leadsfield.value = leadsfield.value.replace(/[^a-zA-Z0-9 ]/, '');
+        }
+  var ownersfield = document.getElementsByClassName('regex-owners')[0];
+        ownersfield.onkeyup = function() {
+            ownersfield.value = ownersfield.value.replace(/[^a-zA-Z0-9 ]/, '');
+        }
 </script>
   
 </html>

--- a/app/views/layouts/software_records.html.erb
+++ b/app/views/layouts/software_records.html.erb
@@ -49,6 +49,27 @@
     }
     });
   }
+
+  var createdbyfield = document.getElementsByClassName('regex-createdby')[0];
+        createdbyfield.onkeyup = function() {
+            createdbyfield.value = createdbyfield.value.replace(/[^a-zA-Z0-9 ]/, '');
+        }
+  var developerfield = document.getElementsByClassName('regex-developers')[0];
+        developerfield.onkeyup = function() {
+            developerfield.value = developerfield.value.replace(/[^a-zA-Z0-9 ]/, '');
+        }
+  var departmentfield = document.getElementsByClassName('regex-departments')[0];
+        departmentfield.onkeyup = function() {
+            departmentfield.value = departmentfield.value.replace(/[^a-zA-Z0-9 ]/, '');
+        }
+  var leadsfield = document.getElementsByClassName('regex-leads')[0];
+        leadsfield.onkeyup = function() {
+            leadsfield.value = leadsfield.value.replace(/[^a-zA-Z0-9 ]/, '');
+        }
+  var ownersfield = document.getElementsByClassName('regex-owners')[0];
+        ownersfield.onkeyup = function() {
+            ownersfield.value = ownersfield.value.replace(/[^a-zA-Z0-9 ]/, '');
+        }
 </script>
   
 </html>

--- a/app/views/shared/_application_nav.html.erb
+++ b/app/views/shared/_application_nav.html.erb
@@ -4,15 +4,16 @@
     <nav class="nav nav-masthead">
        <%= nav_helper 'nav-link' %>
        <% if current_user %>
-       <div class="dropdown show">
-  			<a class="btn btn-secondary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-    			<%= current_user.first_name.to_s+" "+current_user.last_name.to_s %>
-  			</a>
-  			<div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-			    <%= link_to "Logout", destroy_user_session_path, :method => :delete, :class => "nav-link dropdown-item"%>
-			</div>
-		</div>
-		<% end %>
+        <div class="dropdown show">
+    			<a class="btn btn-secondary dropdown-toggle" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      			<%= current_user.first_name.to_s+" "+current_user.last_name.to_s %>
+    			</a>
+    			<div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
+  			    <%= link_to "Logout", destroy_user_session_path, :method => :delete, :class => "nav-link dropdown-item"%>
+  			  </div>
+  		  </div>
+      <% else %>
+		  <% end %>
     </nav>
   </div>
 </div>

--- a/app/views/shared/_dashboard_menu.html.erb
+++ b/app/views/shared/_dashboard_menu.html.erb
@@ -14,20 +14,29 @@
     	<a href="<%= software_types_path %>"><i class="fas fa-file-alt"></i> View all Software Types</a>
   	</div>
 	<br/>
-	<button class="dropdown-btn"><i class="fas fa-user-cog"></i> Editor
+    <button class="dropdown-btn"><i class="fas fa-user-cog"></i> Manager
+        <i class="fa fa-caret-down" style="float: right"></i>
+    </button>
+    <div class="dropdown-container animated fadeIn">
+        <a href="<%= new_software_record_path %>"><i class="fas fa-book"></i> Create Software Record</a>
+        <a href="<%= new_vendor_record_path %>"><i class="fas fa-user-friends"></i> Create Vendor Record</a>
+        <a href="<%= new_software_type_path %>"><i class="fas fa-file-alt"></i> Create Software Type</a>
+        <hr style="background-color: white">
+        <a href="<%= software_records_path %>"><i class="fas fa-book"></i> View all Software Records</a>
+        <a href="<%= vendor_records_path %>"><i class="fas fa-user-friends"></i> View all Vendor Records</a>
+        <a href="<%= software_types_path %>"><i class="fas fa-file-alt"></i> View all Software Types</a>
+    </div>
+    <br/>
+	<button class="dropdown-btn"><i class="fas fa-user-tie"></i> Owner
 		<i class="fa fa-caret-down" style="float: right"></i>
 	</button>
 	<div class="dropdown-container animated fadeIn">
-    	<a href="<%= new_software_record_path %>"><i class="fas fa-book"></i> Create Software Record</a>
-    	<a href="<%= new_vendor_record_path %>"><i class="fas fa-user-friends"></i> Create Vendor Record</a>
-    	<a href="<%= new_software_type_path %>"><i class="fas fa-file-alt"></i> Create Software Type</a>
-        <hr style="background-color: white">
-    	<a href="<%= software_records_path %>"><i class="fas fa-book"></i> View all Software Records</a>
+        <a href="<%= software_records_path %>"><i class="fas fa-book"></i> View all Software Records</a>
     	<a href="<%= vendor_records_path %>"><i class="fas fa-user-friends"></i> View all Vendor Records</a>
     	<a href="<%= software_types_path %>"><i class="fas fa-file-alt"></i> View all Software Types</a>
   	</div>
 	<br/>
-	<button class="dropdown-btn"><i class="fas fa-user-tie"></i> Viewer
+	<button class="dropdown-btn"><i class="fas fa-user-graduate"></i> Viewer
 		<i class="fa fa-caret-down" style="float: right"></i>
 	</button>
 	<div class="dropdown-container animated fadeIn">

--- a/app/views/software_records/_form.html.erb
+++ b/app/views/software_records/_form.html.erb
@@ -10,114 +10,123 @@
               <% end %>
             </div>
           <% end %>
-        <div class="form-group">
-          <%= form.label :title %>
-          <%= form.text_field :title, :class => "form-control" %>
-        </div>
+          <div class="form-group">
+            <%= form.label :title %>
+            <%= form.text_field :title, :class => "form-control" %>
+          </div>
+          
+          <div class="form-group">
+            <%= form.label :description %>
+            <%= form.text_area :description, :class => "form-control" %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :status %>
+            <%= form.select(:status, SoftwareRecord::STATUSES, {} , {:class => "form-control"})%>
+          </div>      
+          
+          <div class="form-group">
+            <%= form.label :date_implemented %>
+            <%= form.date_field :date_implemented, as: :date, value: form.object.try(:strftime,"%m/%d/%Y"), class: 'form-control' %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :date_of_upgrade %>
+            <%= form.date_field :date_of_upgrade, as: :date, value: form.object.try(:strftime,"%m/%d/%Y"), class: 'form-control' %>
+          </div>
+          
+          <div class="form-group">
+            <%= form.label :created_by %>
+            <% if component.eql?("new") %>
+              <%= form.text_field :created_by, value: current_user.first_name + " " +current_user.last_name, :class => "form-control regex-createdby" %>
+            <% else %>
+              <%= form.text_field :created_by, :class => "form-control regex-createdby" %>
+            <% end %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label "Software Type" %>
+            <%= form.collection_select(:software_type_id, SoftwareType.all, :id, :title, {}, {:class => "form-control"}) %>
+          </div>
+          
+          <div class="form-group">
+            <%= form.label "Vendor" %>
+            <%= form.collection_select(:vendor_record_id, VendorRecord.all, :id, :title, {}, {:class => "form-control"}) %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :departments %>
+            <%= form.text_field :departments, :class => "form-control regex-departments" %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :developers %>
+            <%= form.text_field :developers, :class => "form-control regex-developers" %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :tech_leads %>
+            <%= form.text_field :tech_leads, :class => "form-control regex-leads" %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :product_owners %>
+            <%= form.text_field :product_owners, :class => "form-control regex-owners" %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :languages_used %>
+            <%= form.text_field :languages_used, :class => "form-control" %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :url %>
+            <%= form.text_field :url, :class => "form-control" %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :user_seats %>
+            <%= form.text_field :user_seats, :class => "form-control" %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :annual_fees %>
+            <%= form.text_field :annual_fees, :class => "form-control" %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :support_contract %><br/>
+            <%= form.label :support_contract, "Yes", :value => "Yes"  %>
+            <%= form.radio_button :support_contract, "Yes" %>
+            <%= form.label :support_contract, "No", :value => "No" %>
+            <%= form.radio_button :support_contract, "No", :checked => true %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :hosting_environment %>
+            <%= form.text_field :hosting_environment, :class => "form-control" %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :current_version %>
+            <%= form.text_field :current_version, :class => "form-control" %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :notes %>
+            <%= form.text_field :notes, :class => "form-control" %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :business_value %>
+            <%= number_field_tag :business_value, nil, :class => "form-control" %>
+          </div>
+
+          <div class="form-group">
+            <%= form.label :it_quality %>
+            <%= number_field_tag :it_quality, nil, :class => "form-control" %>
+          </div>
         
-        <div class="form-group">
-          <%= form.label :description %>
-          <%= form.text_area :description, :class => "form-control" %>
-        </div>
-        
-        <div class="form-group">
-          <%= form.label :status %>
-          <%= form.select(:status, SoftwareRecord::STATUSES, {} , {:class => "form-control"})%>
-        </div>
-        
-        <div class="form-group">
-          <%= form.label :date_implemented %>
-          <%= form.date_field :date_implemented, as: :date, value: form.object.try(:strftime,"%m/%d/%Y"), class: 'form-control' %>
-        </div>
-        
-        <div class="form-group">
-          <%= form.label :date_of_upgrade %>
-          <%= form.date_field :date_of_upgrade, as: :date, value: form.object.try(:strftime,"%m/%d/%Y"), class: 'form-control' %>
-        </div>
-        
-        <div class="form-group">
-          <%= form.label "Software Type" %>
-          <%= form.collection_select(:software_type_id, SoftwareType.all, :id, :title, {}, {:class => "form-control"}) %>
-        </div>
-        
-        <div class="form-group">
-          <%= form.label "Vendor" %>
-          <%= form.collection_select(:vendor_record_id, VendorRecord.all, :id, :title, {}, {:class => "form-control"}) %>
-        </div>
-
-        <div class="form-group">
-          <%= form.label :departments %>
-          <%= form.text_field :departments, :class => "form-control" %>
-        </div>
-
-        <div class="form-group">
-          <%= form.label :developers %>
-          <%= form.text_field :developers, :class => "form-control" %>
-        </div>
-
-        <div class="form-group">
-          <%= form.label :tech_leads %>
-          <%= form.text_field :tech_leads, :class => "form-control" %>
-        </div>
-
-        <div class="form-group">
-          <%= form.label :product_owners %>
-          <%= form.text_field :product_owners, :class => "form-control" %>
-        </div>
-
-        <div class="form-group">
-          <%= form.label :languages_used %>
-          <%= form.text_field :languages_used, :class => "form-control" %>
-        </div>
-
-        <div class="form-group">
-          <%= form.label :url %>
-          <%= form.text_field :url, :class => "form-control" %>
-        </div>
-
-        <div class="form-group">
-          <%= form.label :user_seats %>
-          <%= form.text_field :user_seats, :class => "form-control" %>
-        </div>
-
-        <div class="form-group">
-          <%= form.label :annual_fees %>
-          <%= form.text_field :annual_fees, :class => "form-control" %>
-        </div>
-
-        <div class="form-group">
-          <%= form.label :support_contract %><br/>
-          <%= form.label :support_contract, "Yes", :value => "Yes"  %>
-          <%= form.radio_button :support_contract, "Yes" %>
-          <%= form.label :support_contract, "No", :value => "No" %>
-          <%= form.radio_button :support_contract, "No", :checked => true %>
-        </div>
-
-        <div class="form-group">
-          <%= form.label :hosting_environment %>
-          <%= form.text_field :hosting_environment, :class => "form-control" %>
-        </div>
-
-        <div class="form-group">
-          <%= form.label :current_version %>
-          <%= form.text_field :current_version, :class => "form-control" %>
-        </div>
-
-        <div class="form-group">
-          <%= form.label :notes %>
-          <%= form.text_field :notes, :class => "form-control" %>
-        </div>
-
-        <div class="form-group">
-          <%= form.label :business_value %>
-          <%= number_field_tag :business_value, nil, :class => "form-control" %>
-        </div>
-
-        <div class="form-group">
-          <%= form.label :it_quality %>
-          <%= number_field_tag :it_quality, nil, :class => "form-control" %>
-        </div>
-
         <br/>
         <div class="form-group <%= component %>" style= "text-align: center;">
           <%= form.submit nil, class: "btn btn-primary" %>

--- a/app/views/software_records/index.html.erb
+++ b/app/views/software_records/index.html.erb
@@ -1,11 +1,12 @@
-
 <section class="jumbotron text-center">
   <div class="container">
     <h1 class="jumbotron-heading display-4" style="text-align: center; color: black; font-family: Courier New, Lucida, Console">Software Records</h1>
     <em style="font-size: 14px; color: black">Collection of all the software applications that are maintained by UC Libraries.</em><br/><br/>
-    <p>
-      <%= link_to 'Create a new software record', new_software_record_path, {:class => "mx-auto new-record btn btn-dark"} %>
-    </p>
+    <% if current_user.role.to_s == "admin" or current_user.role.to_s == "manager" %>
+      <p>
+        <%= link_to 'Create a new software record', new_software_record_path, {:class => "mx-auto new-record btn btn-dark"} %>
+      </p>
+    <% end %>
   </div>
   <hr style = "background-color: black; width: 54%;">
 </section>
@@ -23,17 +24,30 @@
                 <i class="fa fa-caret-down" style="float: none"></i>
               <% end %>
             </th>
-            <th colspan="3">Actions</th>
+            <% if current_user.role.to_s == "viewer" %>
+              <th>Actions</th>
+            <% elsif current_user.role.to_s == "owner" %>
+              <th colspan="2">Actions</th>
+            <% else %>
+              <th colspan="3">Actions</th>
+            <% end %>
           </tr>
         </thead>
-
+        
         <tbody>
           <% @software_records.each do |software_record| %>
             <tr>
               <td><%= software_record.title %></td>
-              <td><%= link_to 'View', software_record , { :class => "btn btn-success" }%></td>
-              <td><%= link_to 'Edit', edit_software_record_path(software_record), { :class => "btn btn-primary" } %></td>
-              <td><%= link_to 'Delete', software_record, method: :delete, :class => "btn btn-danger", data: { confirm: 'Are you sure?' } %></td>
+              <% if current_user.role.to_s == "viewer" %>
+                <td><%= link_to 'View', software_record , { :class => "btn btn-success" }%></td>
+              <% elsif current_user.role.to_s == "owner" %>
+                <td><%= link_to 'View', software_record , { :class => "btn btn-success" }%></td>
+                <td><%= link_to 'Edit', edit_software_record_path(software_record), { :class => "btn btn-primary" } %></td>
+              <% else %>
+                <td><%= link_to 'View', software_record , { :class => "btn btn-success" }%></td>
+                <td><%= link_to 'Edit', edit_software_record_path(software_record), { :class => "btn btn-primary" } %></td>
+                <td><%= link_to 'Delete', software_record, method: :delete, :class => "btn btn-danger", data: { confirm: 'Are you sure?' } %></td>
+              <% end %>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/software_records/show.html.erb
+++ b/app/views/software_records/show.html.erb
@@ -13,6 +13,10 @@
       <dl>
         <dt class="inline-block">Created on: <span style="color: white; font-weight: normal"><%= @software_record.created_at.to_date %></span></dt>
 
+        <% if !@software_record.created_by.nil? && !@software_record.created_by.to_s.empty? %>
+          <dt class="inline-block">Created by: <span style="color: white; font-weight: normal"><%= @software_record.created_by.to_s %></span></dt>
+        <% end %>
+
         <% if !@software_record.date_implemented.nil? && !@software_record.date_implemented.to_s.empty? %>
           <dt class="inline-block">Date Implemented: <span style="color: white; font-weight: normal"><%= @software_record.date_implemented.to_date %></span></dt>
         <% end %>
@@ -20,7 +24,27 @@
         <% if !@software_record.date_of_upgrade.nil? && !@software_record.date_of_upgrade.to_s.empty? %>
           <dt class="inline-block">Date of Upgrade: <span style="color: white; font-weight: normal"><%= @software_record.date_of_upgrade.to_date %></span></dt>
         <% end %>
+
+        <% if !@software_record.tentative_date_implemented.nil? && !@software_record.tentative_date_implemented.to_s.empty? %>
+          <dt class="inline-block">Tentative Date of Implementation: <span style="color: white; font-weight: normal"><%= @software_record.tentative_date_implemented.to_date %></span></dt>
+        <% end %>
         
+        <% if !@software_record.software_type_id.nil? && !@software_record.software_type_id.to_s.empty? %>
+          <dt>Software Type</dt>
+          <dd>
+            <ul><%= SoftwareType.find(@software_record.software_type_id).title %>
+            </ul>
+          </dd>
+        <% end %>
+
+        <% if !@software_record.vendor_record_id.nil? && !@software_record.vendor_record_id.to_s.empty? %>
+          <dt>Vendor</dt>
+          <dd>
+            <ul><%= VendorRecord.find(@software_record.vendor_record_id).title %>
+            </ul>
+          </dd>
+        <% end %>
+
         <% if !@software_record.developers.nil? && !@software_record.developers.to_s.empty? %>
           <dt>Developers</dt>
           <dd>
@@ -32,6 +56,13 @@
           <dt>Tech Leads</dt>
           <dd>
             <ul><%= @software_record.tech_leads %></ul>
+          </dd>
+        <% end %>
+
+        <% if !@software_record.departments.nil? && !@software_record.departments.to_s.empty? %>
+          <dt>Departments</dt>
+          <dd>
+            <ul><%= @software_record.departments %></ul>
           </dd>
         <% end %>
 
@@ -95,13 +126,17 @@
         <% if !@software_record.business_value.nil? && !@software_record.business_value.to_s.empty? %>
           <dt class="inline-block">Business Value: <span style="color: white; font-weight: normal"><%= @software_record.business_value %></span></dt>
         <% end %>
-
+        
         <% if !@software_record.it_quality.nil? && !@software_record.it_quality.to_s.empty? %>
           <dt class="inline-block">IT Quality: <span style="color: white; font-weight: normal"><%= @software_record.it_quality %></span></dt>
         <% end %>
       </dl>
       <div class="text-center">
-      <%= link_to 'Edit', edit_software_record_path(@software_record), :class => "btn btn-warning nav-links" %>
+        <% if user_signed_in? %>
+          <% if current_user.role.to_s == "owner" or current_user.role.to_s == "admin" or current_user.role.to_s == "manager" %>
+            <%= link_to 'Edit', edit_software_record_path(@software_record), :class => "btn btn-warning nav-links" %>
+          <% end %>
+        <% end %>
       <%= link_to 'Back', software_records_path, :class => "btn btn-primary nav-links"%>
     </div>
     </div>

--- a/app/views/software_types/index.html.erb
+++ b/app/views/software_types/index.html.erb
@@ -1,11 +1,12 @@
-
 <section class="jumbotron text-center">
   <div class="container">
     <h1 class="jumbotron-heading display-4" style="text-align: center; color: black; font-family: Courier New, Lucida, Console">Software Types</h1>
     <em style="font-size: 14px; color: black">Contains list of all software types available</em><br/><br/>
-    <p>
-      <%= link_to 'Create a new software type', new_software_type_path, {:class => "mx-auto new-record btn btn-dark"} %>
-    </p>
+    <% if current_user.role.to_s == "admin" or current_user.role.to_s == "manager" %>
+      <p>
+        <%= link_to 'Create a new software type', new_software_type_path, {:class => "mx-auto new-record btn btn-dark"} %>
+      </p>
+      <% end %> 
   </div>
 </section>
 <hr style = "background-color: black; width: 54%;">
@@ -23,7 +24,13 @@
                 <i class="fa fa-caret-down"></i>
               <% end %>
             </th>
-            <th colspan="3">Actions</th>
+            <% if current_user.role.to_s == "viewer" %>
+              <th>Actions</th>
+            <% elsif current_user.role.to_s == "owner" %>
+              <th colspan="2">Actions</th>
+            <% else %>
+              <th colspan="3">Actions</th>
+            <% end %>
           </tr>
         </thead>
 
@@ -31,9 +38,16 @@
           <% @software_types.each do |software_type| %>
             <tr>
               <td><%= software_type.title %></td>
-              <td><%= link_to 'View', software_type , { :class => "btn btn-success" }%></td>
-              <td><%= link_to 'Edit', edit_software_type_path(software_type), { :class => "btn btn-primary" } %></td>
-              <td><%= link_to 'Delete', software_type, method: :delete, :class => "btn btn-danger", data: { confirm: 'Are you sure?' } %></td>
+              <% if current_user.role.to_s == "viewer" %>
+                <td><%= link_to 'View', software_type , { :class => "btn btn-success" }%></td>
+              <% elsif current_user.role.to_s == "owner" %>
+                <td><%= link_to 'View', software_type , { :class => "btn btn-success" }%></td>
+                <td><%= link_to 'Edit', edit_software_type_path(software_type), { :class => "btn btn-primary" } %></td>
+              <% else %>
+                <td><%= link_to 'View', software_type , { :class => "btn btn-success" }%></td>
+                <td><%= link_to 'Edit', edit_software_type_path(software_type), { :class => "btn btn-primary" } %></td>
+                <td><%= link_to 'Delete', software_type, method: :delete, :class => "btn btn-danger", data: { confirm: 'Are you sure?' } %></td>
+              <% end %>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/software_types/show.html.erb
+++ b/app/views/software_types/show.html.erb
@@ -8,7 +8,9 @@
         </blockquote>
 		<br/>
       <div class="text-center">
-        <%= link_to 'Edit', edit_software_type_path(@software_type), :class => "btn btn-warning nav-links" %>
+        <% if current_user.role.to_s == "owner" or current_user.role.to_s == "admin" or current_user.role.to_s == "manager" %>
+          <%= link_to 'Edit', edit_software_type_path(@software_type), :class => "btn btn-warning nav-links" %>
+        <% end %>
         <%= link_to 'Back', software_types_path, :class => "btn btn-primary nav-links"%>
       </div>
     </div>

--- a/app/views/vendor_records/index.html.erb
+++ b/app/views/vendor_records/index.html.erb
@@ -1,11 +1,12 @@
-
 <section class="jumbotron text-center">
   <div class="container">
     <h1 class="jumbotron-heading display-4" style="text-align: center; color: black; font-family: Courier New, Lucida, Console">Vendor Records</h1>
     <em style="font-size: 14px; color: black">Contains all information of vendors available till date</em><br/><br/>
-    <p>
-      <%= link_to 'Create a new vendor record', new_vendor_record_path, {:class => "mx-auto new-record btn btn-dark"} %>
-    </p>
+    <% if current_user.role.to_s == "admin" or current_user.role.to_s == "manager" %>
+      <p>
+        <%= link_to 'Create a new vendor record', new_vendor_record_path, {:class => "mx-auto new-record btn btn-dark"} %>
+      </p>
+    <% end %>
   </div>
 </section>
 <hr style = "background-color: black; width: 54%;">
@@ -23,7 +24,13 @@
                 <i class="fa fa-caret-down"></i>
               <% end %>
             </th>
-            <th colspan="3">Actions</th>
+            <% if current_user.role.to_s == "viewer" %>
+              <th>Actions</th>
+            <% elsif current_user.role.to_s == "owner" %>
+              <th colspan="2">Actions</th>
+            <% else %>
+              <th colspan="3">Actions</th>
+            <% end %>
           </tr>
         </thead>
 
@@ -31,9 +38,16 @@
           <% @vendor_records.each do |vendor_record| %>
             <tr>
               <td><%= vendor_record.title %></td>
-              <td><%= link_to 'View', vendor_record , { :class => "btn btn-success" }%></td>
-              <td><%= link_to 'Edit', edit_vendor_record_path(vendor_record), { :class => "btn btn-primary" } %></td>
-              <td><%= link_to 'Delete', vendor_record, method: :delete, :class => "btn btn-danger", data: { confirm: 'Are you sure?' } %></td>
+              <% if current_user.role.to_s == "viewer" %>
+                <td><%= link_to 'View', vendor_record , { :class => "btn btn-success" }%></td>
+              <% elsif current_user.role.to_s == "owner" %>
+                <td><%= link_to 'View', vendor_record , { :class => "btn btn-success" }%></td>
+                <td><%= link_to 'Edit', edit_vendor_record_path(vendor_record), { :class => "btn btn-primary" } %></td>
+              <% else %>
+                <td><%= link_to 'View', vendor_record , { :class => "btn btn-success" }%></td>
+                <td><%= link_to 'Edit', edit_vendor_record_path(vendor_record), { :class => "btn btn-primary" } %></td>
+                <td><%= link_to 'Delete', vendor_record, method: :delete, :class => "btn btn-danger", data: { confirm: 'Are you sure?' } %></td>
+              <% end %>
             </tr>
           <% end %>
         </tbody>

--- a/app/views/vendor_records/show.html.erb
+++ b/app/views/vendor_records/show.html.erb
@@ -1,4 +1,3 @@
-
 <div class="container animated bounceIn" style="display:flex; justify-content: center; align-items: center; height: 85vh; opacity: 0.9">
   <div class = "card" style = "background-color: black; width: 40%">
     <div class = "card-body">
@@ -7,7 +6,9 @@
             <div class="blockquote-footer"><cite title="Source Title"><%= @vendor_record.description %></cite></div>
         </blockquote>
       <div class="text-center">
-        <%= link_to 'Edit', edit_vendor_record_path(@vendor_record), :class => "btn btn-warning nav-links" %>
+        <% if current_user.role.to_s == "owner" or current_user.role.to_s == "admin" or current_user.role.to_s == "manager" %>
+          <%= link_to 'Edit', edit_vendor_record_path(@vendor_record), :class => "btn btn-warning nav-links" %>
+        <% end %>
         <%= link_to 'Back', vendor_records_path, :class => "btn btn-primary nav-links"%>
       </div>
     </div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -33,9 +33,10 @@ Rails.application.configure do
   config.active_storage.service = :local
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,7 +65,10 @@ Rails.application.configure do
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "application_portfolio_#{Rails.env}"
 
+  config.action_mailer.raise_delivery_errors = true
+
   config.action_mailer.perform_caching = false
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,4 +11,6 @@ Rails.application.routes.draw do
   get '/contact', to: 'front#contact'
   get '/dashboard', to: 'front#dashboard'
   get '/myprofile', to: 'front#profile'
+  get '/request/new', to: 'front#new'
+  post '/request', to: 'front#create'
 end

--- a/db/migrate/20200107154824_add_fields_to_software_records.rb
+++ b/db/migrate/20200107154824_add_fields_to_software_records.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Add fields to SoftwareRecords table
+class AddFieldsToSoftwareRecords < ActiveRecord::Migration[5.2]
+  def change
+    add_column :software_records, :tentative_date_implemented, :date
+    add_column :software_records, :created_by, :string
+  end
+end

--- a/db/migrate/20200108212345_change_roles_column.rb
+++ b/db/migrate/20200108212345_change_roles_column.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Add default value to roles column as viewer
+class ChangeRolesColumn < ActiveRecord::Migration[5.2]
+  def change
+    change_column :users, :roles, :string, default: 'viewer'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_191_219_144_051) do
+ActiveRecord::Schema.define(version: 20_200_109_221_915) do
   create_table 'software_records', force: :cascade do |t|
     t.string 'title'
     t.text 'description'
@@ -37,6 +37,8 @@ ActiveRecord::Schema.define(version: 20_191_219_144_051) do
     t.string 'notes'
     t.integer 'business_value'
     t.integer 'it_quality'
+    t.date 'tentative_date_implemented'
+    t.string 'created_by'
     t.index ['software_type_id'], name: 'index_software_records_on_software_type_id'
     t.index ['vendor_record_id'], name: 'index_software_records_on_vendor_record_id'
   end
@@ -56,7 +58,7 @@ ActiveRecord::Schema.define(version: 20_191_219_144_051) do
     t.datetime 'remember_created_at'
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
-    t.string 'roles'
+    t.string 'roles', default: 'viewer'
     t.string 'first_name'
     t.string 'last_name'
     t.string 'department'

--- a/spec/controllers/front_controller_spec.rb
+++ b/spec/controllers/front_controller_spec.rb
@@ -31,13 +31,13 @@ describe FrontController do
   end
 
   describe '#dashboard' do
-    def sign_in_user(user)
-      sign_in user
+    def sign_in_user(admin)
+      sign_in admin
     end
 
     before do
-      user = FactoryBot.create(:user)
-      sign_in_user(user)
+      admin = FactoryBot.create(:admin)
+      sign_in_user(admin)
     end
 
     it 'renders the dashboard page' do
@@ -48,13 +48,13 @@ describe FrontController do
   end
 
   describe '#profile' do
-    def sign_in_user(user)
-      sign_in user
+    def sign_in_user(admin)
+      sign_in admin
     end
 
     before do
-      user = FactoryBot.create(:user)
-      sign_in_user(user)
+      admin = FactoryBot.create(:admin)
+      sign_in_user(admin)
     end
 
     it 'renders the profile page' do

--- a/spec/controllers/software_types_controller_spec.rb
+++ b/spec/controllers/software_types_controller_spec.rb
@@ -25,6 +25,8 @@ require 'rails_helper'
 # removed from Rails core in Rails 5, but can be added back in via the
 # `rails-controller-testing` gem.
 
+# admin specs
+
 RSpec.describe SoftwareTypesController, type: :controller do
   include Devise::Test::ControllerHelpers
   render_views
@@ -50,13 +52,13 @@ RSpec.describe SoftwareTypesController, type: :controller do
   # VendorRecordsController. Be sure to keep this updated too.
   let(:valid_session) { {} }
 
-  def sign_in_user(user)
-    sign_in user
+  def sign_in_user(admin)
+    sign_in admin
   end
 
   before do
-    user = FactoryBot.create(:user)
-    sign_in_user(user)
+    admin = FactoryBot.create(:admin)
+    sign_in_user(admin)
   end
 
   describe 'GET #index' do
@@ -169,6 +171,456 @@ RSpec.describe SoftwareTypesController, type: :controller do
       software_type = SoftwareType.create! valid_attributes
       delete :destroy, params: { id: software_type.to_param }, session: valid_session
       expect(response).to redirect_to(software_types_url)
+    end
+  end
+end
+
+# manager specs
+
+RSpec.describe SoftwareTypesController, type: :controller do
+  include Devise::Test::ControllerHelpers
+  render_views
+  # This should return the minimal set of attributes required to create a valid
+  # SoftwareType. As you add validations to SoftwareType, be sure to
+  # adjust the attributes here as well.
+  let(:valid_attributes) do
+    {
+      title: 'Desktop',
+      description: 'A desktop application'
+    }
+  end
+
+  let(:invalid_attributes) do
+    {
+      title: '',
+      description: ''
+    }
+  end
+
+  # This should return the minimal set of values that should be in the session
+  # in order to pass any filters (e.g. authentication) defined in
+  # VendorRecordsController. Be sure to keep this updated too.
+  let(:valid_session) { {} }
+
+  def sign_in_user(manager)
+    sign_in manager
+  end
+
+  before do
+    manager = FactoryBot.create(:manager)
+    sign_in_user(manager)
+  end
+
+  describe 'GET #index' do
+    it 'returns a success response' do
+      SoftwareType.create! valid_attributes
+      get :index, params: {}, session: valid_session
+      expect(response).to be_successful
+    end
+
+    it 'has the correct content' do
+      SoftwareType.create! valid_attributes
+      get :index, params: {}, session: valid_session
+      expect(response.body).to have_content('Desktop')
+      expect(response.body).to_not have_content('A desktop application')
+    end
+  end
+
+  describe 'GET #show' do
+    it 'returns a success response' do
+      software_type = SoftwareType.create! valid_attributes
+      get :show, params: { id: software_type.to_param }, session: valid_session
+      expect(response).to be_successful
+      expect(response.body).to have_content('Desktop')
+      expect(response.body).to have_content('A desktop application')
+    end
+  end
+
+  describe 'GET #new' do
+    it 'returns a success response' do
+      get :new, params: {}, session: valid_session
+      expect(response).to be_successful
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe 'GET #edit' do
+    it 'returns a success response' do
+      software_type = SoftwareType.create! valid_attributes
+      get :edit, params: { id: software_type.to_param }, session: valid_session
+      expect(response).to be_successful
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe 'POST #create' do
+    context 'with valid params' do
+      it 'creates a new SoftwareType' do
+        expect do
+          post :create, params: { software_type: valid_attributes }, session: valid_session
+        end.to change(SoftwareType, :count).by(1)
+      end
+
+      it 'redirects to the created software_type' do
+        post :create, params: { software_type: valid_attributes }, session: valid_session
+        expect(response).to redirect_to(SoftwareType.last)
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'new' template)" do
+        post :create, params: { software_type: invalid_attributes }, session: valid_session
+        expect(response).to be_successful
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    context 'with valid params' do
+      let(:new_attributes) do
+        { title: 'Web App', description: 'Web Application' }
+      end
+
+      it 'updates the requested software_type' do
+        software_type = SoftwareType.create! valid_attributes
+        put :update, params: { id: software_type.to_param, software_type: new_attributes }, session: valid_session
+        software_type.reload
+        expect(software_type.title).to eq('Web App')
+        expect(software_type.description).to eq('Web Application')
+      end
+
+      it 'redirects to the software_type' do
+        software_type = SoftwareType.create! valid_attributes
+        put :update, params: { id: software_type.to_param, software_type: valid_attributes }, session: valid_session
+        expect(response).to redirect_to(software_type)
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'edit' template)" do
+        software_type = SoftwareType.create! valid_attributes
+        put :update, params: { id: software_type.to_param, software_type: invalid_attributes }, session: valid_session
+        expect(response).to be_successful
+        expect(response).to render_template(:edit)
+        expect(response.body).to have_content("Title can\\'t be blank")
+        expect(response.body).to have_content("Description can\\'t be blank")
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    it 'destroys the requested software_type' do
+      software_type = SoftwareType.create! valid_attributes
+      expect do
+        delete :destroy, params: { id: software_type.to_param }, session: valid_session
+      end.to change(SoftwareType, :count).by(-1)
+    end
+
+    it 'redirects to the software_types list' do
+      software_type = SoftwareType.create! valid_attributes
+      delete :destroy, params: { id: software_type.to_param }, session: valid_session
+      expect(response).to redirect_to(software_types_url)
+    end
+  end
+end
+
+# owner specs
+
+RSpec.describe SoftwareTypesController, type: :controller do
+  include Devise::Test::ControllerHelpers
+  render_views
+  # This should return the minimal set of attributes required to create a valid
+  # SoftwareType. As you add validations to SoftwareType, be sure to
+  # adjust the attributes here as well.
+  let(:valid_attributes) do
+    {
+      title: 'Desktop',
+      description: 'A desktop application'
+    }
+  end
+
+  let(:invalid_attributes) do
+    {
+      title: '',
+      description: ''
+    }
+  end
+
+  # This should return the minimal set of values that should be in the session
+  # in order to pass any filters (e.g. authentication) defined in
+  # VendorRecordsController. Be sure to keep this updated too.
+  let(:valid_session) { {} }
+
+  def sign_in_user(owner)
+    sign_in owner
+  end
+
+  before do
+    owner = FactoryBot.create(:owner)
+    sign_in_user(owner)
+  end
+
+  describe 'GET #index' do
+    it 'returns a success response' do
+      SoftwareType.create! valid_attributes
+      get :index, params: {}, session: valid_session
+      expect(response).to be_successful
+    end
+
+    it 'has the correct content' do
+      SoftwareType.create! valid_attributes
+      get :index, params: {}, session: valid_session
+      expect(response.body).to have_content('Desktop')
+      expect(response.body).to_not have_content('A desktop application')
+    end
+  end
+
+  describe 'GET #show' do
+    it 'returns a success response' do
+      software_type = SoftwareType.create! valid_attributes
+      get :show, params: { id: software_type.to_param }, session: valid_session
+      expect(response).to be_successful
+      expect(response.body).to have_content('Desktop')
+      expect(response.body).to have_content('A desktop application')
+    end
+  end
+
+  describe 'GET #new' do
+    it 'returns a success response' do
+      get :new, params: {}, session: valid_session
+      expect(response).to_not be_successful
+      expect(response).to_not render_template(:new)
+    end
+  end
+
+  describe 'GET #edit' do
+    it 'returns a success response' do
+      software_type = SoftwareType.create! valid_attributes
+      get :edit, params: { id: software_type.to_param }, session: valid_session
+      expect(response).to be_successful
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe 'POST #create' do
+    context 'with valid params' do
+      it 'creates a new SoftwareType' do
+        expect do
+          post :create, params: { software_type: valid_attributes }, session: valid_session
+        end.to change(SoftwareType, :count).by(0)
+      end
+
+      it 'redirects to the created software_type' do
+        post :create, params: { software_type: valid_attributes }, session: valid_session
+        expect(response).to_not redirect_to(SoftwareType.last)
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'new' template)" do
+        post :create, params: { software_type: invalid_attributes }, session: valid_session
+        expect(response).to_not be_successful
+        expect(response).to_not render_template(:new)
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    context 'with valid params' do
+      let(:new_attributes) do
+        { title: 'Web App', description: 'Web Application' }
+      end
+
+      it 'updates the requested software_type' do
+        software_type = SoftwareType.create! valid_attributes
+        put :update, params: { id: software_type.to_param, software_type: new_attributes }, session: valid_session
+        software_type.reload
+        expect(software_type.title).to eq('Web App')
+        expect(software_type.description).to eq('Web Application')
+      end
+
+      it 'redirects to the software_type' do
+        software_type = SoftwareType.create! valid_attributes
+        put :update, params: { id: software_type.to_param, software_type: valid_attributes }, session: valid_session
+        expect(response).to redirect_to(software_type)
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'edit' template)" do
+        software_type = SoftwareType.create! valid_attributes
+        put :update, params: { id: software_type.to_param, software_type: invalid_attributes }, session: valid_session
+        expect(response).to be_successful
+        expect(response).to render_template(:edit)
+        expect(response.body).to have_content("Title can\\'t be blank")
+        expect(response.body).to have_content("Description can\\'t be blank")
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    it 'destroys the requested software_type' do
+      software_type = SoftwareType.create! valid_attributes
+      expect do
+        delete :destroy, params: { id: software_type.to_param }, session: valid_session
+      end.to change(SoftwareType, :count).by(0)
+    end
+
+    it 'redirects to the software_types list' do
+      software_type = SoftwareType.create! valid_attributes
+      delete :destroy, params: { id: software_type.to_param }, session: valid_session
+      expect(response).to_not redirect_to(software_types_url)
+    end
+  end
+end
+
+# viewer specs
+
+RSpec.describe SoftwareTypesController, type: :controller do
+  include Devise::Test::ControllerHelpers
+  render_views
+  # This should return the minimal set of attributes required to create a valid
+  # SoftwareType. As you add validations to SoftwareType, be sure to
+  # adjust the attributes here as well.
+  let(:valid_attributes) do
+    {
+      title: 'Desktop',
+      description: 'A desktop application'
+    }
+  end
+
+  let(:invalid_attributes) do
+    {
+      title: '',
+      description: ''
+    }
+  end
+
+  # This should return the minimal set of values that should be in the session
+  # in order to pass any filters (e.g. authentication) defined in
+  # VendorRecordsController. Be sure to keep this updated too.
+  let(:valid_session) { {} }
+
+  def sign_in_user(viewer)
+    sign_in viewer
+  end
+
+  before do
+    viewer = FactoryBot.create(:viewer)
+    sign_in_user(viewer)
+  end
+
+  describe 'GET #index' do
+    it 'returns a success response' do
+      SoftwareType.create! valid_attributes
+      get :index, params: {}, session: valid_session
+      expect(response).to be_successful
+    end
+
+    it 'has the correct content' do
+      SoftwareType.create! valid_attributes
+      get :index, params: {}, session: valid_session
+      expect(response.body).to have_content('Desktop')
+      expect(response.body).to_not have_content('A desktop application')
+    end
+  end
+
+  describe 'GET #show' do
+    it 'returns a success response' do
+      software_type = SoftwareType.create! valid_attributes
+      get :show, params: { id: software_type.to_param }, session: valid_session
+      expect(response).to be_successful
+      expect(response.body).to have_content('Desktop')
+      expect(response.body).to have_content('A desktop application')
+    end
+  end
+
+  describe 'GET #new' do
+    it 'returns a success response' do
+      get :new, params: {}, session: valid_session
+      expect(response).to_not be_successful
+      expect(response).to_not render_template(:new)
+    end
+  end
+
+  describe 'GET #edit' do
+    it 'returns a success response' do
+      software_type = SoftwareType.create! valid_attributes
+      get :edit, params: { id: software_type.to_param }, session: valid_session
+      expect(response).to_not be_successful
+      expect(response).to_not render_template(:edit)
+    end
+  end
+
+  describe 'POST #create' do
+    context 'with valid params' do
+      it 'creates a new SoftwareType' do
+        expect do
+          post :create, params: { software_type: valid_attributes }, session: valid_session
+        end.to change(SoftwareType, :count).by(0)
+      end
+
+      it 'redirects to the created software_type' do
+        post :create, params: { software_type: valid_attributes }, session: valid_session
+        expect(response).to_not redirect_to(SoftwareType.last)
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'new' template)" do
+        post :create, params: { software_type: invalid_attributes }, session: valid_session
+        expect(response).to_not be_successful
+        expect(response).to_not render_template(:new)
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    context 'with valid params' do
+      let(:new_attributes) do
+        { title: 'Web App', description: 'Web Application' }
+      end
+
+      it 'updates the requested software_type' do
+        software_type = SoftwareType.create! valid_attributes
+        put :update, params: { id: software_type.to_param, software_type: new_attributes }, session: valid_session
+        software_type.reload
+        expect(software_type.title).to_not eq('Web App')
+        expect(software_type.description).to_not eq('Web Application')
+      end
+
+      it 'redirects to the software_type' do
+        software_type = SoftwareType.create! valid_attributes
+        put :update, params: { id: software_type.to_param, software_type: valid_attributes }, session: valid_session
+        expect(response).to_not redirect_to(software_type)
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'edit' template)" do
+        software_type = SoftwareType.create! valid_attributes
+        put :update, params: { id: software_type.to_param, software_type: invalid_attributes }, session: valid_session
+        expect(response).to_not be_successful
+        expect(response).to_not render_template(:edit)
+        expect(response.body).to_not have_content("Title can\\'t be blank")
+        expect(response.body).to_not have_content("Description can\\'t be blank")
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    it 'destroys the requested software_type' do
+      software_type = SoftwareType.create! valid_attributes
+      expect do
+        delete :destroy, params: { id: software_type.to_param }, session: valid_session
+      end.to change(SoftwareType, :count).by(0)
+    end
+
+    it 'redirects to the software_types list' do
+      software_type = SoftwareType.create! valid_attributes
+      delete :destroy, params: { id: software_type.to_param }, session: valid_session
+      expect(response).to_not redirect_to(software_types_url)
     end
   end
 end

--- a/spec/controllers/vendor_records_controller_spec.rb
+++ b/spec/controllers/vendor_records_controller_spec.rb
@@ -25,6 +25,8 @@ require 'rails_helper'
 # removed from Rails core in Rails 5, but can be added back in via the
 # `rails-controller-testing` gem.
 
+# admin specs
+
 RSpec.describe VendorRecordsController, type: :controller do
   include Devise::Test::ControllerHelpers
   render_views
@@ -50,13 +52,13 @@ RSpec.describe VendorRecordsController, type: :controller do
   # VendorRecordsController. Be sure to keep this updated too.
   let(:valid_session) { {} }
 
-  def sign_in_user(user)
-    sign_in user
+  def sign_in_user(admin)
+    sign_in admin
   end
 
   before do
-    user = FactoryBot.create(:user)
-    sign_in_user(user)
+    admin = FactoryBot.create(:admin)
+    sign_in_user(admin)
   end
 
   describe 'GET #index' do
@@ -167,6 +169,450 @@ RSpec.describe VendorRecordsController, type: :controller do
       vendor_record = VendorRecord.create! valid_attributes
       delete :destroy, params: { id: vendor_record.to_param }, session: valid_session
       expect(response).to redirect_to(vendor_records_url)
+    end
+  end
+end
+
+# manager specs
+
+RSpec.describe VendorRecordsController, type: :controller do
+  include Devise::Test::ControllerHelpers
+  render_views
+  # This should return the minimal set of attributes required to create a valid
+  # VendorRecord. As you add validations to VendorRecord, be sure to
+  # adjust the attributes here as well.
+  let(:valid_attributes) do
+    {
+      title: 'A Test Vendor',
+      description: 'A Good testing vendor record'
+    }
+  end
+
+  let(:invalid_attributes) do
+    {
+      title: '',
+      description: ''
+    }
+  end
+
+  # This should return the minimal set of values that should be in the session
+  # in order to pass any filters (e.g. authentication) defined in
+  # VendorRecordsController. Be sure to keep this updated too.
+  let(:valid_session) { {} }
+
+  def sign_in_user(manager)
+    sign_in manager
+  end
+
+  before do
+    manager = FactoryBot.create(:manager)
+    sign_in_user(manager)
+  end
+
+  describe 'GET #index' do
+    it 'returns a success response' do
+      VendorRecord.create! valid_attributes
+      get :index, params: {}, session: valid_session
+      expect(response).to be_successful
+    end
+
+    it 'has the correct content' do
+      VendorRecord.create! valid_attributes
+      get :index, params: {}, session: valid_session
+      expect(response.body).to have_content('A Test Vendor')
+    end
+  end
+
+  describe 'GET #show' do
+    it 'returns a success response' do
+      vendor_record = VendorRecord.create! valid_attributes
+      get :show, params: { id: vendor_record.to_param }, session: valid_session
+      expect(response).to be_successful
+      expect(response.body).to have_content('A Test Vendor')
+    end
+  end
+
+  describe 'GET #new' do
+    it 'returns a success response' do
+      get :new, params: {}, session: valid_session
+      expect(response).to be_successful
+      expect(response).to render_template(:new)
+    end
+  end
+
+  describe 'GET #edit' do
+    it 'returns a success response' do
+      vendor_record = VendorRecord.create! valid_attributes
+      get :edit, params: { id: vendor_record.to_param }, session: valid_session
+      expect(response).to be_successful
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe 'POST #create' do
+    context 'with valid params' do
+      it 'creates a new VendorRecord' do
+        expect do
+          post :create, params: { vendor_record: valid_attributes }, session: valid_session
+        end.to change(VendorRecord, :count).by(1)
+      end
+
+      it 'redirects to the created vendor_record' do
+        post :create, params: { vendor_record: valid_attributes }, session: valid_session
+        expect(response).to redirect_to(VendorRecord.last)
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'new' template)" do
+        post :create, params: { vendor_record: invalid_attributes }, session: valid_session
+        expect(response).to be_successful
+        expect(response).to render_template(:new)
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    context 'with valid params' do
+      let(:new_attributes) do
+        { title: 'A Test Vendor v2.0', description: 'Another testing vendor record' }
+      end
+
+      it 'updates the requested vendor_record' do
+        vendor_record = VendorRecord.create! valid_attributes
+        put :update, params: { id: vendor_record.to_param, vendor_record: new_attributes }, session: valid_session
+        vendor_record.reload
+        expect(vendor_record.title).to eq('A Test Vendor v2.0')
+        expect(vendor_record.description).to eq('Another testing vendor record')
+      end
+
+      it 'redirects to the vendor_record' do
+        vendor_record = VendorRecord.create! valid_attributes
+        put :update, params: { id: vendor_record.to_param, vendor_record: valid_attributes }, session: valid_session
+        expect(response).to redirect_to(vendor_record)
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'edit' template)" do
+        vendor_record = VendorRecord.create! valid_attributes
+        put :update, params: { id: vendor_record.to_param, vendor_record: invalid_attributes }, session: valid_session
+        expect(response).to be_successful
+        expect(response).to render_template(:edit)
+        expect(response.body).to have_content("Title can\\'t be blank")
+        expect(response.body).to have_content("Description can\\'t be blank")
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    it 'destroys the requested vendor_record' do
+      vendor_record = VendorRecord.create! valid_attributes
+      expect do
+        delete :destroy, params: { id: vendor_record.to_param }, session: valid_session
+      end.to change(VendorRecord, :count).by(-1)
+    end
+
+    it 'redirects to the vendor_records list' do
+      vendor_record = VendorRecord.create! valid_attributes
+      delete :destroy, params: { id: vendor_record.to_param }, session: valid_session
+      expect(response).to redirect_to(vendor_records_url)
+    end
+  end
+end
+
+# owner specs
+
+RSpec.describe VendorRecordsController, type: :controller do
+  include Devise::Test::ControllerHelpers
+  render_views
+  # This should return the minimal set of attributes required to create a valid
+  # VendorRecord. As you add validations to VendorRecord, be sure to
+  # adjust the attributes here as well.
+  let(:valid_attributes) do
+    {
+      title: 'A Test Vendor',
+      description: 'A Good testing vendor record'
+    }
+  end
+
+  let(:invalid_attributes) do
+    {
+      title: '',
+      description: ''
+    }
+  end
+
+  # This should return the minimal set of values that should be in the session
+  # in order to pass any filters (e.g. authentication) defined in
+  # VendorRecordsController. Be sure to keep this updated too.
+  let(:valid_session) { {} }
+
+  def sign_in_user(owner)
+    sign_in owner
+  end
+
+  before do
+    owner = FactoryBot.create(:owner)
+    sign_in_user(owner)
+  end
+
+  describe 'GET #index' do
+    it 'returns a success response' do
+      VendorRecord.create! valid_attributes
+      get :index, params: {}, session: valid_session
+      expect(response).to be_successful
+    end
+
+    it 'has the correct content' do
+      VendorRecord.create! valid_attributes
+      get :index, params: {}, session: valid_session
+      expect(response.body).to have_content('A Test Vendor')
+    end
+  end
+
+  describe 'GET #show' do
+    it 'returns a success response' do
+      vendor_record = VendorRecord.create! valid_attributes
+      get :show, params: { id: vendor_record.to_param }, session: valid_session
+      expect(response).to be_successful
+      expect(response.body).to have_content('A Test Vendor')
+    end
+  end
+
+  describe 'GET #new' do
+    it 'returns a success response' do
+      get :new, params: {}, session: valid_session
+      expect(response).to_not be_successful
+      expect(response).to_not render_template(:new)
+    end
+  end
+
+  describe 'GET #edit' do
+    it 'returns a success response' do
+      vendor_record = VendorRecord.create! valid_attributes
+      get :edit, params: { id: vendor_record.to_param }, session: valid_session
+      expect(response).to be_successful
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  describe 'POST #create' do
+    context 'with valid params' do
+      it 'creates a new VendorRecord' do
+        expect do
+          post :create, params: { vendor_record: valid_attributes }, session: valid_session
+        end.to change(VendorRecord, :count).by(0)
+      end
+
+      it 'redirects to the created vendor_record' do
+        post :create, params: { vendor_record: valid_attributes }, session: valid_session
+        expect(response).to_not redirect_to(VendorRecord.last)
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'new' template)" do
+        post :create, params: { vendor_record: invalid_attributes }, session: valid_session
+        expect(response).to_not be_successful
+        expect(response).to_not render_template(:new)
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    context 'with valid params' do
+      let(:new_attributes) do
+        { title: 'A Test Vendor v2.0', description: 'Another testing vendor record' }
+      end
+
+      it 'updates the requested vendor_record' do
+        vendor_record = VendorRecord.create! valid_attributes
+        put :update, params: { id: vendor_record.to_param, vendor_record: new_attributes }, session: valid_session
+        vendor_record.reload
+        expect(vendor_record.title).to eq('A Test Vendor v2.0')
+        expect(vendor_record.description).to eq('Another testing vendor record')
+      end
+
+      it 'redirects to the vendor_record' do
+        vendor_record = VendorRecord.create! valid_attributes
+        put :update, params: { id: vendor_record.to_param, vendor_record: valid_attributes }, session: valid_session
+        expect(response).to redirect_to(vendor_record)
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'edit' template)" do
+        vendor_record = VendorRecord.create! valid_attributes
+        put :update, params: { id: vendor_record.to_param, vendor_record: invalid_attributes }, session: valid_session
+        expect(response).to be_successful
+        expect(response).to render_template(:edit)
+        expect(response.body).to have_content("Title can\\'t be blank")
+        expect(response.body).to have_content("Description can\\'t be blank")
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    it 'destroys the requested vendor_record' do
+      vendor_record = VendorRecord.create! valid_attributes
+      expect do
+        delete :destroy, params: { id: vendor_record.to_param }, session: valid_session
+      end.to change(VendorRecord, :count).by(0)
+    end
+
+    it 'redirects to the vendor_records list' do
+      vendor_record = VendorRecord.create! valid_attributes
+      delete :destroy, params: { id: vendor_record.to_param }, session: valid_session
+      expect(response).to_not redirect_to(vendor_records_url)
+    end
+  end
+end
+
+# viewer specs
+
+RSpec.describe VendorRecordsController, type: :controller do
+  include Devise::Test::ControllerHelpers
+  render_views
+  # This should return the minimal set of attributes required to create a valid
+  # VendorRecord. As you add validations to VendorRecord, be sure to
+  # adjust the attributes here as well.
+  let(:valid_attributes) do
+    {
+      title: 'A Test Vendor',
+      description: 'A Good testing vendor record'
+    }
+  end
+
+  let(:invalid_attributes) do
+    {
+      title: '',
+      description: ''
+    }
+  end
+
+  # This should return the minimal set of values that should be in the session
+  # in order to pass any filters (e.g. authentication) defined in
+  # VendorRecordsController. Be sure to keep this updated too.
+  let(:valid_session) { {} }
+
+  def sign_in_user(viewer)
+    sign_in viewer
+  end
+
+  before do
+    viewer = FactoryBot.create(:viewer)
+    sign_in_user(viewer)
+  end
+
+  describe 'GET #index' do
+    it 'returns a success response' do
+      VendorRecord.create! valid_attributes
+      get :index, params: {}, session: valid_session
+      expect(response).to be_successful
+    end
+
+    it 'has the correct content' do
+      VendorRecord.create! valid_attributes
+      get :index, params: {}, session: valid_session
+      expect(response.body).to have_content('A Test Vendor')
+    end
+  end
+
+  describe 'GET #show' do
+    it 'returns a success response' do
+      vendor_record = VendorRecord.create! valid_attributes
+      get :show, params: { id: vendor_record.to_param }, session: valid_session
+      expect(response).to be_successful
+      expect(response.body).to have_content('A Test Vendor')
+    end
+  end
+
+  describe 'GET #new' do
+    it 'returns a success response' do
+      get :new, params: {}, session: valid_session
+      expect(response).to_not be_successful
+      expect(response).to_not render_template(:new)
+    end
+  end
+
+  describe 'GET #edit' do
+    it 'returns a success response' do
+      vendor_record = VendorRecord.create! valid_attributes
+      get :edit, params: { id: vendor_record.to_param }, session: valid_session
+      expect(response).to_not be_successful
+      expect(response).to_not render_template(:edit)
+    end
+  end
+
+  describe 'POST #create' do
+    context 'with valid params' do
+      it 'creates a new VendorRecord' do
+        expect do
+          post :create, params: { vendor_record: valid_attributes }, session: valid_session
+        end.to change(VendorRecord, :count).by(0)
+      end
+
+      it 'redirects to the created vendor_record' do
+        post :create, params: { vendor_record: valid_attributes }, session: valid_session
+        expect(response).to_not redirect_to(VendorRecord.last)
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'new' template)" do
+        post :create, params: { vendor_record: invalid_attributes }, session: valid_session
+        expect(response).to_not be_successful
+        expect(response).to_not render_template(:new)
+      end
+    end
+  end
+
+  describe 'PUT #update' do
+    context 'with valid params' do
+      let(:new_attributes) do
+        { title: 'A Test Vendor v2.0', description: 'Another testing vendor record' }
+      end
+
+      it 'updates the requested vendor_record' do
+        vendor_record = VendorRecord.create! valid_attributes
+        put :update, params: { id: vendor_record.to_param, vendor_record: new_attributes }, session: valid_session
+        vendor_record.reload
+        expect(vendor_record.title).to_not eq('A Test Vendor v2.0')
+        expect(vendor_record.description).to_not eq('Another testing vendor record')
+      end
+
+      it 'redirects to the vendor_record' do
+        vendor_record = VendorRecord.create! valid_attributes
+        put :update, params: { id: vendor_record.to_param, vendor_record: valid_attributes }, session: valid_session
+        expect(response).to_not redirect_to(vendor_record)
+      end
+    end
+
+    context 'with invalid params' do
+      it "returns a success response (i.e. to display the 'edit' template)" do
+        vendor_record = VendorRecord.create! valid_attributes
+        put :update, params: { id: vendor_record.to_param, vendor_record: invalid_attributes }, session: valid_session
+        expect(response).to_not be_successful
+        expect(response).to_not render_template(:edit)
+        expect(response.body).to_not have_content("Title can\\'t be blank")
+        expect(response.body).to_not have_content("Description can\\'t be blank")
+      end
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    it 'destroys the requested vendor_record' do
+      vendor_record = VendorRecord.create! valid_attributes
+      expect do
+        delete :destroy, params: { id: vendor_record.to_param }, session: valid_session
+      end.to change(VendorRecord, :count).by(0)
+    end
+
+    it 'redirects to the vendor_records list' do
+      vendor_record = VendorRecord.create! valid_attributes
+      delete :destroy, params: { id: vendor_record.to_param }, session: valid_session
+      expect(response).to_not redirect_to(vendor_records_url)
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,11 +1,39 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :user, class: 'User' do
+  factory :viewer, class: 'User' do
     first_name { 'Random' }
-    last_name { 'User' }
-    email { 'random@gmail.com' }
+    last_name { 'Viewer' }
+    email { 'viewer@test.com' }
     password { 'random123' }
     password_confirmation { 'random123' }
+    roles { 'viewer' }
+  end
+
+  factory :admin, class: 'User' do
+    first_name { 'Random' }
+    last_name { 'Admin' }
+    email { 'admin@test.com' }
+    password { 'random123' }
+    password_confirmation { 'random123' }
+    roles { 'admin' }
+  end
+
+  factory :manager, class: 'User' do
+    first_name { 'Random' }
+    last_name { 'Manager' }
+    email { 'manager@test.com' }
+    password { 'random123' }
+    password_confirmation { 'random123' }
+    roles { 'manager' }
+  end
+
+  factory :owner, class: 'User' do
+    first_name { 'Random' }
+    last_name { 'Owner' }
+    email { 'owner@test.com' }
+    password { 'random123' }
+    password_confirmation { 'random123' }
+    roles { 'owner' }
   end
 end

--- a/spec/helpers/software_records_helper_spec.rb
+++ b/spec/helpers/software_records_helper_spec.rb
@@ -13,4 +13,14 @@ require 'rails_helper'
 #   end
 # end
 RSpec.describe SoftwareRecordsHelper, type: :helper do
+  describe 'pills' do
+    it 'returns correct value' do
+      expect(helper.pills('In Design')).to eq('<span class="badge badge-pill badge-info">In Design</span>')
+      expect(helper.pills('In Development')).to eq('<span class="badge badge-pill badge-light">In Development</span>')
+      expect(helper.pills('Production')).to eq('<span class="badge badge-pill badge-primary">Production</span>')
+      expect(helper.pills('Available')).to eq('<span class="badge badge-pill badge-success">Available</span>')
+      expect(helper.pills('To be decomissioned')).to eq('<span class="badge badge-pill badge-danger">To be decomissioned</span>')
+      expect(helper.pills('Something')).to eq('<span class="badge badge-pill badge-dark">Something</span>')
+    end
+  end
 end

--- a/spec/models/software_record_spec.rb
+++ b/spec/models/software_record_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SoftwareRecord, type: :model do
     )
   end
   it 'is valid if all required fields are provided' do
-    softwarerecord = SoftwareRecord.new(title: 'Scholar UC', description: 'UC Digital conservatory preservation library', status: 'In Progress', software_type_id: SoftwareType.first.id, vendor_record_id: VendorRecord.first.id)
+    softwarerecord = SoftwareRecord.new(title: 'Scholar UC', description: 'UC Digital conservatory preservation library', status: 'In Progress', software_type_id: SoftwareType.first.id, vendor_record_id: VendorRecord.first.id, created_by: 'Test User')
     expect(softwarerecord).to be_valid
   end
 
@@ -40,6 +40,11 @@ RSpec.describe SoftwareRecord, type: :model do
 
   it 'is valid if all required fields are provided (without vendor_record_id)' do
     softwarerecord = SoftwareRecord.new(title: 'Scholar UC', status: 'In Progress', description: 'UC Digital conservatory preservation library', vendor_record_id: VendorRecord.first.id)
+    expect(softwarerecord).to_not be_valid
+  end
+
+  it 'is not valid without a single mandatory field (without created_by)' do
+    softwarerecord = SoftwareRecord.new(description: 'UC Digital conservatory preservation library', status: 'In Progress', software_type_id: SoftwareType.first.id, vendor_record_id: VendorRecord.first.id)
     expect(softwarerecord).to_not be_valid
   end
 end

--- a/spec/models/user_test.rb
+++ b/spec/models/user_test.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 class UserTest < ActiveSupport::TestCase
-  RSpec.describe SoftwareType, type: :model do
+  RSpec.describe User, type: :model do
     it 'is valid user if all required fields are provided' do
       user = User.new(first_name: 'Random', last_name: 'User', email: 'random@example.com', password: 'random@123', password_confirmation: 'random@123')
       expect(user).to be_valid

--- a/spec/requests/front_spec.rb
+++ b/spec/requests/front_spec.rb
@@ -3,13 +3,13 @@
 require 'rails_helper'
 
 RSpec.describe 'FrontController', type: :request do
-  def sign_in_user(user)
-    sign_in user
+  def sign_in_user(admin)
+    sign_in admin
   end
 
   before do
-    user = FactoryBot.create(:user)
-    sign_in_user(user)
+    admin = FactoryBot.create(:admin)
+    sign_in_user(admin)
   end
 
   describe 'GET /about' do

--- a/spec/requests/software_records_spec.rb
+++ b/spec/requests/software_records_spec.rb
@@ -3,18 +3,25 @@
 require 'rails_helper'
 
 RSpec.describe 'SoftwareRecords', type: :request do
-  def sign_in_user(user)
-    sign_in user
+  def sign_in_user(admin)
+    sign_in admin
   end
 
-  before do
-    user = FactoryBot.create(:user)
-    sign_in_user(user)
+  before(:each) do
+    admin = FactoryBot.create(:admin)
+    sign_in_user(admin)
   end
 
   describe 'GET /software_records' do
     it 'requests /software_records' do
       get software_records_path
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'GET /software_records/new' do
+    it 'requests /software_records/new' do
+      get new_software_record_path
       expect(response).to have_http_status(200)
     end
   end

--- a/spec/requests/software_types_spec.rb
+++ b/spec/requests/software_types_spec.rb
@@ -3,18 +3,101 @@
 require 'rails_helper'
 
 RSpec.describe 'SoftwareTypes', type: :request do
-  def sign_in_user(user)
-    sign_in user
+  def sign_in_user(admin)
+    sign_in admin
   end
 
   before do
-    user = FactoryBot.create(:user)
-    sign_in_user(user)
+    admin = FactoryBot.create(:admin)
+    sign_in_user(admin)
   end
+
   describe 'GET /software_types' do
-    it 'works! (now write some real specs)' do
+    it 'requests /software_types' do
       get software_types_path
       expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'GET /software_types/new' do
+    it 'requests /software_types/new' do
+      get new_software_type_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end
+
+RSpec.describe 'SoftwareTypes', type: :request do
+  def sign_in_user(manager)
+    sign_in manager
+  end
+
+  before do
+    manager = FactoryBot.create(:manager)
+    sign_in_user(manager)
+  end
+
+  describe 'GET /software_types' do
+    it 'requests /software_types' do
+      get software_types_path
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'GET /software_types/new' do
+    it 'requests /software_types/new' do
+      get new_software_type_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end
+
+RSpec.describe 'SoftwareTypes', type: :request do
+  def sign_in_user(viewer)
+    sign_in viewer
+  end
+
+  before do
+    viewer = FactoryBot.create(:viewer)
+    sign_in_user(viewer)
+  end
+
+  describe 'GET /software_types' do
+    it 'requests /software_types' do
+      get software_types_path
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'GET /software_records/new' do
+    it 'requests /software_records/new' do
+      get new_software_type_path
+      expect(response).to_not have_http_status(200)
+    end
+  end
+end
+
+RSpec.describe 'SoftwareTypes', type: :request do
+  def sign_in_user(owner)
+    sign_in owner
+  end
+
+  before do
+    owner = FactoryBot.create(:owner)
+    sign_in_user(owner)
+  end
+
+  describe 'GET /software_types' do
+    it 'requests /software_types' do
+      get software_types_path
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'GET /software_types/new' do
+    it 'requests /software_types/new' do
+      get new_software_type_path
+      expect(response).to_not have_http_status(200)
     end
   end
 end

--- a/spec/requests/vendor_records_spec.rb
+++ b/spec/requests/vendor_records_spec.rb
@@ -3,18 +3,101 @@
 require 'rails_helper'
 
 RSpec.describe 'VendorRecords', type: :request do
-  def sign_in_user(user)
-    sign_in user
+  def sign_in_user(admin)
+    sign_in admin
   end
 
   before do
-    user = FactoryBot.create(:user)
-    sign_in_user(user)
+    admin = FactoryBot.create(:admin)
+    sign_in_user(admin)
   end
+
   describe 'GET /vendor_records' do
-    it 'works! (now write some real specs)' do
+    it 'requests /vendor_records' do
       get vendor_records_path
       expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'GET /vendor_records/new' do
+    it 'requests /vendor_records/new' do
+      get new_vendor_record_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end
+
+RSpec.describe 'VendorRecords', type: :request do
+  def sign_in_user(manager)
+    sign_in manager
+  end
+
+  before do
+    manager = FactoryBot.create(:manager)
+    sign_in_user(manager)
+  end
+
+  describe 'GET /vendor_records' do
+    it 'requests /vendor_records' do
+      get vendor_records_path
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'GET /vendor_records/new' do
+    it 'requests /vendor_records/new' do
+      get new_vendor_record_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end
+
+RSpec.describe 'VendorRecords', type: :request do
+  def sign_in_user(viewer)
+    sign_in viewer
+  end
+
+  before do
+    viewer = FactoryBot.create(:viewer)
+    sign_in_user(viewer)
+  end
+
+  describe 'GET /vendor_records' do
+    it 'requests /vendor_records' do
+      get vendor_records_path
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'GET /vendor_records/new' do
+    it 'requests /vendor_records/new' do
+      get new_vendor_record_path
+      expect(response).to_not have_http_status(200)
+    end
+  end
+end
+
+RSpec.describe 'VendorRecords', type: :request do
+  def sign_in_user(owner)
+    sign_in owner
+  end
+
+  before do
+    owner = FactoryBot.create(:owner)
+    sign_in_user(owner)
+  end
+
+  describe 'GET /vendor_records' do
+    it 'requests /vendor_records' do
+      get vendor_records_path
+      expect(response).to have_http_status(200)
+    end
+  end
+
+  describe 'GET /vendor_records/new' do
+    it 'requests /vendor_records/new' do
+      get new_vendor_record_path
+      expect(response).to_not have_http_status(200)
     end
   end
 end

--- a/spec/views/front/dashboard.html.erb_spec.rb
+++ b/spec/views/front/dashboard.html.erb_spec.rb
@@ -4,15 +4,18 @@ require 'rails_helper'
 
 RSpec.describe 'front/dashboard', type: :view do
   before(:each) do
-    @softwarerecords_indesign = SoftwareRecordsController.indesign_dashboard
-    @softwarerecords_production = SoftwareRecordsController.production_dashboard
+    allow(view).to(receive(:user_signed_in?) { true }) && allow(view).to(receive(:current_user) { FactoryBot.build(:admin) })
+    admin = FactoryBot.build(:admin)
+    @softwarerecords_indesign = SoftwareRecordsController.indesign_dashboard(admin)
+    @softwarerecords_production = SoftwareRecordsController.production_dashboard(admin)
   end
 
   it 'displays an dashboard page' do
     render
     expect(rendered).to have_text('Users')
+    expect(rendered).to have_text('My Software Records In-Design/Development')
+    expect(rendered).to have_text('My Software Records In Production')
     expect(rendered).to have_text('Software Records')
-    expect(rendered).to have_text('Software Types')
     expect(rendered).to have_text('Vendor Records')
   end
 end

--- a/spec/views/front/index.html.erb_spec.rb
+++ b/spec/views/front/index.html.erb_spec.rb
@@ -13,15 +13,13 @@ end
 
 describe 'front/index' do
   context 'when user is created' do
-    let(:user) { FactoryBot.create(:user) }
-
-    before do
-      sign_in user
+    before(:each) do
+      allow(view).to(receive(:user_signed_in?) { true }) && allow(view).to(receive(:current_user) { FactoryBot.build(:admin) })
     end
 
     it 'displays who is logged in' do
       render
-      expect(rendered).to have_text('Logged in as random@gmail.com')
+      expect(rendered).to have_text('Logged in as admin@test.com')
       expect(controller.request.path_parameters[:controller]).to eq('front')
     end
 

--- a/spec/views/front/profile.html.erb_spec.rb
+++ b/spec/views/front/profile.html.erb_spec.rb
@@ -3,10 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe 'front/profile', type: :view do
-  let(:user) { FactoryBot.create(:user) }
-
-  before do
-    sign_in user
+  before(:each) do
+    allow(view).to(receive(:user_signed_in?) { true }) && allow(view).to(receive(:current_user) { FactoryBot.build(:admin) })
   end
 
   it 'displays an profile page' do

--- a/spec/views/front/welcome.html.erb_spec.rb
+++ b/spec/views/front/welcome.html.erb_spec.rb
@@ -3,11 +3,10 @@
 require 'rails_helper'
 
 describe 'front/welcome' do
-  let(:user) { FactoryBot.create(:user) }
-
-  before do
-    sign_in user
+  before(:each) do
+    allow(view).to(receive(:user_signed_in?) { true }) && allow(view).to(receive(:current_user) { FactoryBot.build(:admin) })
   end
+
   it 'displays an welcome page' do
     render
     expect(rendered).to have_text('Logged in as')

--- a/spec/views/index.html.erb_spec.rb
+++ b/spec/views/index.html.erb_spec.rb
@@ -13,17 +13,16 @@ end
 
 describe 'front/index' do
   context 'when user is created' do
-    let(:user) { FactoryBot.create(:user) }
+    let(:admin) { FactoryBot.create(:admin) }
 
     before do
-      sign_in user
+      sign_in admin
     end
 
     it 'displays who is logged in' do
       render
-      expect(rendered).to have_text('Logged in as random@gmail.com')
+      expect(rendered).to have_text('Logged in as admin@test.com')
       expect(controller.request.path_parameters[:controller]).to eq('front')
-      print(response.body)
     end
 
     it 'displays a logout link' do

--- a/spec/views/software_records/edit.html.erb_spec.rb
+++ b/spec/views/software_records/edit.html.erb_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe 'software_records/edit', type: :view do
                                                   description: 'MyText',
                                                   status: 'MyString',
                                                   software_type_id: SoftwareType.first.id,
-                                                  vendor_record_id: VendorRecord.first.id
+                                                  vendor_record_id: VendorRecord.first.id,
+                                                  created_by: 'Test User'
                                                 ))
   end
 

--- a/spec/views/software_records/index.html.erb_spec.rb
+++ b/spec/views/software_records/index.html.erb_spec.rb
@@ -18,16 +18,19 @@ RSpec.describe 'software_records/index', type: :view do
                description: 'MyText',
                status: 'Status',
                vendor_record_id: VendorRecord.first.id,
-               software_type_id: SoftwareType.first.id
+               software_type_id: SoftwareType.first.id,
+               created_by: 'Test User'
              ),
              SoftwareRecord.create!(
                title: 'Title',
                description: 'MyText',
                status: 'Status',
                vendor_record_id: VendorRecord.first.id,
-               software_type_id: SoftwareType.first.id
+               software_type_id: SoftwareType.first.id,
+               created_by: 'Test User'
              )
            ])
+    allow(view).to(receive(:user_signed_in?) { true }) && allow(view).to(receive(:current_user) { FactoryBot.build(:admin) })
   end
 
   it 'renders a list of software_records' do

--- a/spec/views/software_records/new.html.erb_spec.rb
+++ b/spec/views/software_records/new.html.erb_spec.rb
@@ -12,12 +12,14 @@ RSpec.describe 'software_records/new', type: :view do
       title: 'Web app',
       description: 'test software type'
     )
+    allow(view).to(receive(:user_signed_in?) { true }) && allow(view).to(receive(:current_user) { FactoryBot.build(:admin) })
     @software_record = assign(:software_record, SoftwareRecord.new(
                                                   title: 'MyString',
                                                   description: 'MyText',
                                                   status: 'MyString',
                                                   software_type_id: SoftwareType.first.id,
-                                                  vendor_record_id: VendorRecord.first.id
+                                                  vendor_record_id: VendorRecord.first.id,
+                                                  created_by: 'Test User'
                                                 ))
   end
 

--- a/spec/views/software_records/show.html.erb_spec.rb
+++ b/spec/views/software_records/show.html.erb_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe 'software_records/show', type: :view do
                                                   description: 'MyText',
                                                   status: 'MyString',
                                                   software_type_id: SoftwareType.first.id,
-                                                  vendor_record_id: VendorRecord.first.id
+                                                  vendor_record_id: VendorRecord.first.id,
+                                                  created_by: 'Test User'
                                                 ))
   end
 

--- a/spec/views/software_types/index.html.erb_spec.rb
+++ b/spec/views/software_types/index.html.erb_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'software_types/index', type: :view do
                description: 'MyText'
              )
            ])
+    allow(view).to(receive(:user_signed_in?) { true }) && allow(view).to(receive(:current_user) { FactoryBot.build(:admin) })
   end
   it 'renders a list of software_types' do
     render

--- a/spec/views/software_types/show.html.erb_spec.rb
+++ b/spec/views/software_types/show.html.erb_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'software_types/show', type: :view do
                                               title: 'Title',
                                               description: 'MyText'
                                             ))
+    allow(view).to(receive(:user_signed_in?) { true }) && allow(view).to(receive(:current_user) { FactoryBot.build(:admin) })
   end
 
   it 'renders attributes in <p>' do

--- a/spec/views/vendor_records/index.html.erb_spec.rb
+++ b/spec/views/vendor_records/index.html.erb_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'vendor_records/index', type: :view do
                description: 'MyText'
              )
            ])
+    allow(view).to(receive(:user_signed_in?) { true }) && allow(view).to(receive(:current_user) { FactoryBot.build(:admin) })
   end
 
   it 'renders a list of vendor_records' do

--- a/spec/views/vendor_records/show.html.erb_spec.rb
+++ b/spec/views/vendor_records/show.html.erb_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'vendor_records/show', type: :view do
                                               title: 'Name',
                                               description: 'MyText'
                                             ))
+    allow(view).to(receive(:user_signed_in?) { true }) && allow(view).to(receive(:current_user) { FactoryBot.build(:admin) })
   end
 
   it 'renders attributes in <p>' do


### PR DESCRIPTION
Fixes #57 #58 #59 #60 #62 #64 

1) Added a "Request Software" button for an unauthenticated user
2) Pops out a thin form for requesting of software by an unauthenticated user
3) Emails admin as soon as the software is requested
4) A "viewer" role user can only view index page and cannot create, edit delete any record
5) An "admin" role user can access anything and delete any record (has all privileges)
6) A "manager" role user has the same privileges as the "admin" role.
7) An "owner" role user can view, edit any record.
8) Enhanced dashboard as "MY" experience (for software-records in-design/in-development, production tables) of the logged-in user.
9) Changed the SoftwareType bar-graph on the dashboard to a line-graph for Software Records by grouping them based on created week.