### PR TITLE
Trigger Email on new user signup to all admins

### DIFF
--- a/app/mailers/new_user_signup_mailer.rb
+++ b/app/mailers/new_user_signup_mailer.rb
@@ -7,7 +7,7 @@ class NewUserSignupMailer < ApplicationMailer
   def new_user_signup_mail(id, email, first_name, last_name)
     @id = id
     @email = email
-    @name = first_name.to_s+" "+last_name
+    @name = first_name.to_s + ' ' + last_name
     @template = 'new_user_signup_mail.html.erb'
     @users = User.where(roles: 'root_admin')
     @users.each do |admin|

--- a/app/mailers/new_user_signup_mailer.rb
+++ b/app/mailers/new_user_signup_mailer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# Admin Mailer on Software Record request
+class NewUserSignupMailer < ApplicationMailer
+  default from: 'uclappdev@uc.edu'
+
+  def new_user_signup_mail(id, email, first_name, last_name)
+    @id = id
+    @email = email
+    @name = first_name.to_s+" "+last_name
+    @template = 'new_user_signup_mail.html.erb'
+    @users = User.where(roles: 'root_admin')
+    @users.each do |admin|
+      mail(to: admin.email, subject: 'New User registered in UCL Application Portfolio', template_name: @template).deliver
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,9 +15,15 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable, password_length: 10..128
 
+  after_create :send_admin_mail
+
   def allow_uc_domains
     allowed_domains = ['uc.edu', 'mail.uc.edu', 'ucmail.uc.edu']
     errors.add(:email, 'for Signup must be an UC email') unless allowed_domains.any? { |domain| email.end_with?(domain) }
+  end
+  
+  def send_admin_mail
+    NewUserSignupMailer.new_user_signup_mail(self.id, self.email, self.first_name, self.last_name).deliver_now
   end
 
   def active_for_authentication?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,9 +21,9 @@ class User < ApplicationRecord
     allowed_domains = ['uc.edu', 'mail.uc.edu', 'ucmail.uc.edu']
     errors.add(:email, 'for Signup must be an UC email') unless allowed_domains.any? { |domain| email.end_with?(domain) }
   end
-  
+
   def send_admin_mail
-    NewUserSignupMailer.new_user_signup_mail(self.id, self.email, self.first_name, self.last_name).deliver_now
+    NewUserSignupMailer.new_user_signup_mail(id, email, first_name, last_name).deliver_now
   end
 
   def active_for_authentication?

--- a/app/views/new_user_signup_mailer/new_user_signup_mail.html.erb
+++ b/app/views/new_user_signup_mailer/new_user_signup_mail.html.erb
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <p>Hi Admin<br><br>
+
+	A New User is registered in the UCL Application Portfolio. Please find the details of the new user below.
+
+	Name: <%= @name %>
+	Email: <a href="<%= @email %>"><%= @email %></a>
+
+	<% @host_url = ENV['APP_PORTFOLIO_PRODUCTION_MAILER_URL'] %>
+	<a href="https://<%= @host_url %>/users/<%= @id %>">https://<%= @host_url %>/users/<%= @id %></a></p><br><br>
+  </body>
+</html> 

--- a/app/views/new_user_signup_mailer/new_user_signup_mail.text.erb
+++ b/app/views/new_user_signup_mailer/new_user_signup_mail.text.erb
@@ -1,0 +1,9 @@
+Hi Admin
+
+A New User is registered in the UCL Application Portfolio. Please find the details of the new user below.
+
+Name: <%= @name %>
+Email: <%= @email %>
+
+<% @host_url = ENV['APP_PORTFOLIO_PRODUCTION_MAILER_URL'] %>
+https://<%= @host_url %>/users/<%= @id %>">

--- a/spec/mailers/new_user_signup_mailer_spec.rb
+++ b/spec/mailers/new_user_signup_mailer_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe NewUserSignupMailer, type: :mailer do
       )
     end
     it 'sends an email on new software request' do
+      FactoryBot.create(:admin)
       mail = described_class.new_user_signup_mail(user.id, user.email, user.first_name, user.last_name).deliver_now
       expect(mail.subject).to eq('New User registered in UCL Application Portfolio')
       expect(mail.from).to eq(['uclappdev@uc.edu'])

--- a/spec/mailers/new_user_signup_mailer_spec.rb
+++ b/spec/mailers/new_user_signup_mailer_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe NewUserSignupMailer, type: :mailer do
+  describe 'new_user_signup_mail' do
+    let(:user) do
+      User.create!(
+        first_name: 'Tony',
+        last_name: 'Stark',
+        email: 'tony.stark@uc.edu',
+        roles: 'viewer',
+        department: 'Robotics',
+        title: 'Iron Man',
+        password: 'jarvis_12345',
+        password_confirmation: 'jarvis_12345'
+      )
+    end
+    it 'sends an email on new software request' do
+      mail = described_class.new_user_signup_mail(user.id, user.email, user.first_name, user.last_name).deliver_now
+      expect(mail.subject).to eq('New User registered in UCL Application Portfolio')
+      expect(mail.from).to eq(['uclappdev@uc.edu'])
+      expect(mail.body.encoded).to match(user.first_name + ' ' + user.last_name)
+      expect(mail.body.encoded).to match('A New User is registered in the UCL Application Portfolio. Please find the details of the new user below.')
+    end
+  end
+end

--- a/spec/mailers/previews/new_user_signup_preview.rb
+++ b/spec/mailers/previews/new_user_signup_preview.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class NewUserSignupMailer < ActionMailer::Preview
+  def new_user_signup
+    NewUserSignupMailer.new_user_signup_mail(User.id, User.email, User.first_name, User.last_name)
+  end
+end


### PR DESCRIPTION
Fixes #131 

- Trigger an email notification to all application admins when a new user signup into the application.