### PR TITLE
add new fields to import/export scripts

### DIFF
--- a/exports/software_records.rb
+++ b/exports/software_records.rb
@@ -9,8 +9,14 @@ class SoftwareRecords < ApplicationRecord
   def software_records
     file = "#{Dir.pwd}/public/software_records.csv"
     software_records = SoftwareRecords.all
+    # general metadata
     headers = ['Software Record', 'Description', 'Status', 'Created on', 'Software Type', 'Authentication Type', 'Vendor Record', 'Departments', 'Date Implemented', 'Date of upgrade', 'Developers', 'Tech Leads', 'Product Owners', 'Languages Used', 'Production URL', 'Source Code URL', 'User Seats', 'Annual Fees', 'Support Contract', 'Hosting Environment',
                'Current Version', 'Notes', 'Business Value', 'IT Quality', 'Created By']
+    # change management metadata
+    headers += ['Requires Chanage Management review?', 'Last Security Scan', 'Last Accessibility Scan', 'Last OGC Review', 'Last Infosec Review', 'CM Stakeholders', 'CM Other Notes']
+
+    # server env metadtata
+    headers += ['QA URL', 'Dev_URL', 'Prod_URL', 'Production Support Servers', 'Last Record Change', 'Track Uptime', 'Monitor Health', 'Monitor Errors']
 
     CSV.open(file, 'w', write_headers: true, headers: headers) do |writer|
       software_records.each do |software_record|
@@ -103,7 +109,7 @@ class SoftwareRecords < ApplicationRecord
         the_product_owners = '' if the_product_owners.to_s == "''"
 
         writer << [software_record.title, software_record.description, Status.find_by(id: software_record.status_id).title, software_record.created_at, SoftwareType.find_by(id: software_record.software_type_id).title, software_record.authentication_type, VendorRecord.find_by(id: software_record.vendor_record_id).title, the_departments, software_record.date_implemented,
-                   software_record.date_of_upgrade, the_developers, the_techleads, the_product_owners, software_record.languages_used, software_record.production_url, software_record.source_code_url, software_record.user_seats, software_record.annual_fees, software_record.support_contract, HostingEnvironment.find_by(id: software_record.hosting_environment_id).title, software_record.current_version, software_record.notes, software_record.business_value, software_record.it_quality, software_record.created_by]
+                   software_record.date_of_upgrade, the_developers, the_techleads, the_product_owners, software_record.languages_used, software_record.production_url, software_record.source_code_url, software_record.user_seats, software_record.annual_fees, software_record.support_contract, HostingEnvironment.find_by(id: software_record.hosting_environment_id).title, software_record.current_version, software_record.notes, software_record.business_value, software_record.it_quality, software_record.created_by, software_record.requires_cm, software_record.last_security_scan, software_record.last_accessibility_scan, software_record.last_ogc_review, last_info_sec_review, software_record.cm_stakeholders, software_record.cm_other_notes, software_record.qa_url, software_record.dev_url, software_record.prod_url, software_record.production_support_servers, software_record.last_record_change, software_record.track_uptime, software_record.monitor_health, software_record.monitor_errors]
       end
     end
   end

--- a/load_records.rb
+++ b/load_records.rb
@@ -166,13 +166,22 @@ class LoadRecords < ApplicationRecord
         date_of_upgrade = row['Date of upgrade'].to_s.strip
         authentication_type = row['Authentication Type'].to_s.strip
         # change managmeent fields
-        requires_cm_review = row['Requires Chanage Management review?'].to_s.strip
-        last_security_scan = row['Last security scan'].to_s.strip
-        last_accessibility_scan = row['Last accessibility scan'].to_s.strip
-        last_ogc_review = row['Last OGC review'].to_s.strip
-        last_info_sec_review = row['Last Infosec review'].to_s.strip
+        requires_cm = row['Requires Chanage Management review?'].to_s.strip
+        last_security_scan = row['Last Security Scan'].to_s.strip
+        last_accessibility_scan = row['Last Accessibility Scan'].to_s.strip
+        last_ogc_review = row['Last OGC Review'].to_s.strip
+        last_info_sec_review = row['Last Infosec Review'].to_s.strip
         cm_stakeholders = row['CM Stakeholders'].to_s.strip
-        cm_other_notes = row['CM other notes'].to_s.strip
+        cm_other_notes = row['CM Other Notes'].to_s.strip
+        # serven env fields
+        qa_url = row['QA URL'].to_s.strip
+        dev_url = row['Dev URL'].to_s.strip
+        prod_url = row['Prod URL'].to_s.strip
+        production_support_servers = row['Production Support Servers'].to_s.strip
+        last_record_change = row['Last Record Change'].to_s.strip
+        track_uptime = row['Track Uptime'].to_s.strip
+        monitor_health = row['Monitor Health'].to_s.strip
+        monitor_errors = row['Monitor Errors'].to_s.strip
 
         if !SoftwareRecord.find_by(title: title).nil? && SoftwareRecord.find_by(title: title).title.to_s == title && SoftwareRecord.find_by(title: title).software_type_id == software_type_id && SoftwareRecord.find_by(title: title).vendor_record_id == vendor_record_id
           puts("Software Record '#{title}' is found in the db and hence suppressing it.")
@@ -201,7 +210,7 @@ class LoadRecords < ApplicationRecord
                              created_by: created_by,
                              sensitive_information: sensitive_information,
                              authentication_type: authentication_type,
-                             requires_cm_review: requires_cm_review,
+                             requires_cm: requires_cm,
                              last_security_scan: last_security_scan,
                              last_accessibility_scan: last_accessibility_scan,
                              last_ogc_review: last_ogc_review,

--- a/spec/exports/software_records_spec.rb
+++ b/spec/exports/software_records_spec.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require "#{Dir.pwd}/exports/software_records.rb"
+
+RSpec.describe SoftwareRecords do
+  describe 'software_records' do
+  end
+end

--- a/spec/load_records_spec.rb
+++ b/spec/load_records_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require "#{Dir.pwd}/load_records.rb"
+
+RSpec.describe LoadRecords do
+  describe 'software_records' do
+    it 'can load general metadata' do
+      LoadRecords.table_name = 'software_records'
+      expect(LoadRecords.new).to respond_to(:title,
+                                            :description,
+                                            :status_id,
+                                            :software_type_id,
+                                            :vendor_record_id,
+                                            :departments,
+                                            :date_implemented,
+                                            :developers,
+                                            :tech_leads,
+                                            :product_owners,
+                                            :languages_used,
+                                            :production_url,
+                                            :source_code_url,
+                                            :user_seats,
+                                            :annual_fees,
+                                            :support_contract,
+                                            :hosting_environment_id,
+                                            :current_version,
+                                            :notes,
+                                            :business_value,
+                                            :it_quality,
+                                            :created_by,
+                                            :sensitive_information,
+                                            :authentication_type)
+    end
+
+    it 'can load change management metadata' do
+      LoadRecords.table_name = 'software_records'
+      expect(LoadRecords.new).to respond_to(:requires_cm,
+                                            :last_security_scan,
+                                            :last_accessibility_scan,
+                                            :last_ogc_review,
+                                            :last_info_sec_review,
+                                            :cm_stakeholders,
+                                            :cm_other_notes)
+    end
+
+    it 'can load server env metadata' do
+      LoadRecords.table_name = 'software_records'
+      expect(LoadRecords.new).to respond_to(:date_of_upgrade,
+                                            :qa_url,
+                                            :dev_url,
+                                            :prod_url,
+                                            :production_support_servers,
+                                            :last_record_change,
+                                            :track_uptime,
+                                            :monitor_health,
+                                            :monitor_errors)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #208 

Add metadata fields to import and export scripts for new software record tabs. 
Add spec for load_records.rb
Add empty spec for export/software_records.rb