### PR TITLE
Add local option to auth type

### DIFF
--- a/app/views/software_records/_form_general.html.erb
+++ b/app/views/software_records/_form_general.html.erb
@@ -44,7 +44,7 @@
             
             <div class="form-group">
               <%= form.label "Authentication Type" %>
-              <%= form.select(:authentication_type, ['None', 'DUO', 'LDAP','E-Directory','Shibboleth'], {}, { :class => 'form-control' }) %>
+              <%= form.select(:authentication_type, t('authentication_types'), {}, { :class => 'form-control' }) %>
             </div>
 
             <!-- Multiple Departments -->

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,5 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  hello: 'Hello world'
+  authentication_types: ['None', 'DUO', 'LDAP','E-Directory','Shibboleth', 'Local']

--- a/spec/views/software_records/edit.html.erb_spec.rb
+++ b/spec/views/software_records/edit.html.erb_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe 'software_records/edit', type: :view do
   it 'renders the edit software_record form' do
     render
 
+    expect(rendered).to have_select('software_record_authentication_type', with_options: %w[DUO LDAP E-Directory Shibboleth Local])
+
     assert_select 'form[action=?][method=?]', software_record_path(@software_record), 'post' do
       assert_select 'input[name=?]', 'software_record[title]'
       assert_select 'textarea[name=?]', 'software_record[description]'

--- a/spec/views/software_records/new.html.erb_spec.rb
+++ b/spec/views/software_records/new.html.erb_spec.rb
@@ -37,6 +37,8 @@ RSpec.describe 'software_records/new', type: :view do
   it 'renders new software_record form' do
     render
 
+    expect(rendered).to have_select('software_record_authentication_type', with_options: %w[DUO LDAP E-Directory Shibboleth Local])
+
     assert_select 'form[action=?][method=?]', software_records_path, 'post' do
       assert_select 'input[name=?]', 'software_record[title]'
 


### PR DESCRIPTION
Resolves #244 

* Add 'Local' option to auth type select for Software Records. 
* Extract options to i18n locale.