### PR TITLE
Replace packaged brakeman github action with command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,4 @@ jobs:
     - name: Bundler Audit Action
       uses: andrewmcodes/bundler-audit-action@v0.1.0
     - name: Brakeman linter
-      uses: devmasx/brakeman-linter-action@v1.0.0
-      env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      run: bundle exec brakeman --no-exit-on-warn --no-exit-on-error


### PR DESCRIPTION
Resolves #309 

The marketplace plugin we were using for brakeman had an error related to versioning. This is a hazard of using plugins that may be stale or not have much attention to maintenance. 

In this PR, I have removed that marketplace plugin and opted to run brakeman directly. We have some options to configure this: by default, brakeman will return an error code for any warnings or errors and will prevent the ci job from passing. Unfortunately, running it on the CL like this doesn't provide any context to the error code. It just fails the build and says brakeman returned error code 3 (which means there were warnings). I think this would be okay if we're all comfortable with checking the log to see what the issue is. 

Alternatively, we can include flags to the brakeman call telling it to not return error codes and just pass after running the check. 

I suppose we need to decide whether we want brakeman warnings to systematically prevent merging a commit.

@scherztc thoughts? 