### PR TITLE
Adds Maintentance Log and Priority list

### DIFF
--- a/app/controllers/software_records_controller.rb
+++ b/app/controllers/software_records_controller.rb
@@ -138,11 +138,35 @@ class SoftwareRecordsController < ApplicationController
     decrypt sensitive_data if sensitive_data.to_s.present?
   end
 
+  def list_upgrades
+    $page_title = 'Maintenance Priority| UCL Application Portfolio'
+    @params = request.query_parameters
+
+    @software_records = if @params['filter_by'].to_s == 'software_types' && !@params['software_type_filter'].nil? && !@params['software_type_filter'].empty?
+                          SoftwareRecord.where(software_type_id: @params['software_type_filter']).order("#{sort_priority} #{sort_direction_priority}")
+                        elsif @params['filter_by'].to_s == 'vendor_records' && !@params['vendor_record_filter'].nil? && !@params['vendor_record_filter'].empty?
+                          SoftwareRecord.where(vendor_record_id: @params['vendor_record_filter']).order("#{sort_priority} #{sort_direction_priority}")
+                        else
+                          SoftwareRecord.order("#{sort_priority} #{sort_direction_priority}")
+                        end
+    @vendor_records = VendorRecord.all
+    @software_types = SoftwareType.all
+    @softwarerecords_count = SoftwareRecord.count
+  end
+
   private
 
   # Use callbacks to share common setup or constraints between actions.
   def set_software_record
     @software_record = SoftwareRecord.find(params[:id])
+  end
+
+  def sort_priority
+    SoftwareRecord.column_names.include?(params[:sort]) ? params[:sort] : 'priority'
+  end
+
+  def sort_direction_priority
+    %w[asc desc].include?(params[:direction]) ? params[:direction] : 'desc'
   end
 
   def sort_column
@@ -192,6 +216,23 @@ class SoftwareRecordsController < ApplicationController
       :track_uptime,
       :monitor_health,
       :monitor_errors,
+      :service,
+      :installed_version,
+      :latest_version,
+      :proposed_version,
+      :last_upgrade_date,
+      :upgrade_available,
+      :vulnerabilities_reported,
+      :vulnerabilities_fixed,
+      :bug_fixes,
+      :new_features,
+      :breaking_changes,
+      :end_of_life,
+      :priority,
+      :upgrade_status,
+      :who,
+      :semester,
+      :upgrade_docs,
       tech_leads: [],
       developers: [],
       product_owners: [],

--- a/app/views/shared/_dashboard_menu.html.erb
+++ b/app/views/shared/_dashboard_menu.html.erb
@@ -17,6 +17,7 @@
                 <a href="<%= statuses_path %>"><i class="far fa-file-alt float-right"></i> View all Status</a>
                 <a href="<%= hosting_environments_path %>"><i class="fab fa-envira float-right"></i> View all Hosting Env.'s</a>
                 <hr style="background-color: white">
+                <a href="<%= list_upgrades_path %>"><i class="fas fa-users float-right"></i> Next Software Upgrades</a>
                 <a href="<%= users_path %>"><i class="fas fa-users float-right"></i> Manage all Users</a>
                 <a href="<%= file_uploads_new_path %>"><i class="fas fa-file-import float-right"></i> Import Data</a>
                 <hr style="background-color: white">
@@ -39,6 +40,8 @@
                 <a href="<%= software_types_path %>"><i class="fas fa-file-alt float-right"></i> View all Software Types</a>
                 <a href="<%= statuses_path %>"><i class="far fa-file-alt float-right"></i> View all Status</a>
                 <a href="<%= hosting_environments_path %>"><i class="fab fa-envira float-right"></i> View all Hosting Env.'s</a>
+                <hr style="background-color: white">
+                <a href="<%= list_upgrades_path %>"><i class="fas fa-users float-right"></i> Next Software Upgrades</a>
             </div>
             <br/>
             <% end %>
@@ -52,6 +55,8 @@
                 <a href="<%= software_types_path %>"><i class="fas fa-file-alt float-right"></i> View all Software Types</a>
                 <a href="<%= statuses_path %>"><i class="far fa-file-alt float-right"></i> View all Status</a>
                 <a href="<%= hosting_environments_path %>"><i class="fab fa-envira float-right"></i> View all Hosting Env.'s</a>
+                <hr style="background-color: white">
+                <a href="<%= list_upgrades_path %>"><i class="fas fa-users float-right"></i> Next Software Upgrades</a>
                 <hr style="background-color: white">
                 <a href="<%= export_software_records_path %>"><i class="fas fa-file-export float-right"></i> Export Software Records</a>
                 <a href="<%= export_software_types_path %>"><i class="fas fa-file-export float-right"></i> Export Software Types</a>

--- a/app/views/software_records/_form.html.erb
+++ b/app/views/software_records/_form.html.erb
@@ -22,6 +22,10 @@
           <a class="nav-link" id="upgrade-history-tab" data-toggle="tab" href="#upgrade-history" role="tab" aria-controls="contact"
             aria-selected="false">Upgrade History</a>
         </li>
+        <li class="nav-item">
+          <a class="nav-link" id="maintenance-log-tab" data-toggle="tab" href="#maintenance-log" role="tab" aria-controls="contact"
+            aria-selected="false">Maintenance Log</a>
+        </li>
       </ul>
 
     <div class = "card-body">
@@ -45,6 +49,9 @@
         </div>
         <div class="tab-pane fade" id="upgrade-history" role="tabpanel">
           <%= render 'form_upgrade_history', software_record: @software_record, component: component, form: form %>
+        </div>
+        <div class="tab-pane fade" id="maintenance-log" role="tabpanel">
+          <%= render 'form_maintenance_log', software_record: @software_record, component: component, form: form %>
         </div>
 
         <div class="form-group <%= component %>" style= "text-align: center;">

--- a/app/views/software_records/_form_maintenance_log.html.erb
+++ b/app/views/software_records/_form_maintenance_log.html.erb
@@ -1,0 +1,88 @@
+<!-- app/views/software_records/edit.html.erb -->
+
+<h1>Edit Software Record</h1>
+
+  <div class="form-group">
+    <%= form.label :service %>
+    <%= form.text_field :service, :class => "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :installed_version %>
+    <%= form.text_field :installed_version, :class => "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :latest_version %>
+    <%= form.text_field :latest_version, :class => "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :proposed_version %>
+    <%= form.text_field :proposed_version, :class => "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :last_upgrade_date %>
+    <%= form.date_field :last_upgrade_date, as: :date, value: form.object.try(:strftime,"%m/%d/%Y"), :class => "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :upgrade_available %>
+    <%= form.check_box :upgrade_available, :class => "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :vulnerabilities_reported %>
+    <%= form.check_box :vulnerabilities_reported, :class => "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :vulnerabilities_fixed %>
+    <%= form.check_box :vulnerabilities_fixed, :class => "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :bug_fixes %>
+    <%= form.check_box :bug_fixes, :class => "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :new_features %>
+    <%= form.check_box :new_features, :class => "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :breaking_changes %>
+    <%= form.check_box :breaking_changes, :class => "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :end_of_life %>
+    <%= form.check_box :end_of_life, :class => "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :priority %>
+    <%= form.text_field :priority, :class => "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :upgrade_status %>
+    <%= form.text_field :upgrade_status, :class => "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :who %>
+    <%= form.text_field :who, :class => "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :semester %>
+    <%= form.text_field :semester, :class => "form-control" %>
+  </div>
+
+  <div class="form-group">
+    <%= form.label :upgrade_docs %>
+    <%= form.text_field :upgrade_docs, :class => "form-control" %>
+  </div>

--- a/app/views/software_records/_maintenance_log.html.erb
+++ b/app/views/software_records/_maintenance_log.html.erb
@@ -1,0 +1,53 @@
+        <dl>
+          <% unless @software_record.service.to_s.blank? %>
+            <dt class="inline-block">Name of Service: <span style="color: white; font-weight: normal"><%= @software_record.service %></span></dt>
+          <% end %>
+          <% unless @software_record.installed_version.to_s.blank? %>
+            <dt class="inline-block">Current Version: <span style="color: white; font-weight: normal"><%= @software_record.installed_version %></span></dt>
+          <% end %>
+          <% unless @software_record.latest_version.to_s.blank? %>
+            <dt class="inline-block">Latest version available: <span style="color: white; font-weight: normal"><%= @software_record.latest_version %></span></dt>
+          <% end %>
+          <% unless @software_record.proposed_version.to_s.blank? %>
+            <dt class="inline-block">Next Proposed version:<span style="color: white; font-weight: normal"><%= @software_record.proposed_version %></span></dt>
+          <% end %>
+          <% unless @software_record.last_upgrade_date.to_s.blank? %>
+            <dt class="inline-block">Last Upgrade Date: <span style="color: white; font-weight: normal"><%= @software_record.last_upgrade_date%></span></dt>
+          <% end %>
+          <% unless @software_record.upgrade_available.blank? %>
+            <dt class="inline-block">Is there an upgrade available:<span style="color: white; font-weight: normal"><%= @software_record.upgrade_available %></span></dt>
+          <% end %>
+          <% unless @software_record.vulnerabilities_reported.blank? %>
+            <dt class="inline-block">Are there vulnerabilities reported?<span style="color: white; font-weight: normal"><%= @software_record.vulnerabilities_reported %></span></dt>
+          <% end %>
+          <% unless @software_record.vulnerabilities_fixed.blank? %>
+            <dt class="inline-block">Does the new version fix vulnerabilities?: <span style="color: white; font-weight: normal"><%= @software_record.vulnerabilities_fixed %></span></dt>
+          <% end %>
+          <% unless @software_record.bug_fixes.blank? %>
+            <dt class="inline-block">Are there bug fixes reported?<span style="color: white; font-weight: normal"><%= @software_record.vulnerabilities_reported %></span></dt>
+          <% end %>
+          <% unless @software_record.new_features.blank? %>
+            <dt class="inline-block">Are there any new features?: <span style="color: white; font-weight: normal"><%= @software_record.new_features %></span></dt>
+          <% end %>
+          <% unless @software_record.breaking_changes.blank? %>
+            <dt class="inline-block">Are there any breaking changes?: <span style="color: white; font-weight: normal"><%= @software_record.breaking_changes %></span></dt>
+          <% end %>
+          <% unless @software_record.end_of_life.blank? %>
+            <dt class="inline-block">Is this an end of life version?: <span style="color: white; font-weight: normal"><%= @software_record.end_of_life %></span></dt>
+          <% end %>
+          <% unless @software_record.priority.blank? %>
+            <dt class="inline-block">Is this a priority: <span style="color: white; font-weight: normal"><%= @software_record.priority %></span></dt>
+          <% end %>
+          <% unless @software_record.upgrade_status.blank? %>
+            <dt class="inline-block">What is the status?: <span style="color: white; font-weight: normal"><%= @software_record.upgrade_status %></span></dt>
+          <% end %>
+          <% unless @software_record.who.blank? %>
+            <dt class="inline-block">Who is responsible?: <span style="color: white; font-weight: normal"><%= @software_record.who %></span></dt>
+          <% end %>
+          <% unless @software_record.semester.blank? %>
+            <dt class="inline-block">What semester is this scheduled for?: <span style="color: white; font-weight: normal"><%= @software_record.semester %></span></dt>
+          <% end %>
+          <% unless @software_record.upgrade_docs.blank? %>
+            <dt class="inline-block">Are there any ugprade links?: <span style="color: white; font-weight: normal"><%= @software_record.new_features %></span></dt>
+          <% end %>
+        </dl>

--- a/app/views/software_records/list_upgrades.html.erb
+++ b/app/views/software_records/list_upgrades.html.erb
@@ -1,0 +1,142 @@
+<section class="jumbotron text-center">
+  <br/>
+  <hr style = "background-color: black; width: 54%;">
+  <div class="container-fluid">
+    <h1 class="jumbotron-heading display-4" style="text-align: center; color: black; font-family: Courier New, Lucida, Console">Maintenace Priorities</h1>
+    <em style="font-size: 14px; color: black">Collection of all the software applications prioritized for Upgrade.</em><br/><br/>
+  </div>
+  <br/>
+  <% if current_user.role.to_s == "root_admin" or current_user.role.to_s == "manager" %>
+    <p>
+      <%= link_to 'Create a new software record', new_software_record_path, {:class => "mx-auto new-record btn btn-dark"} %>
+    </p>
+  <% end %>
+    <form>
+      <p style="font-size: 20px; color: black; display: inline;">Filter based on: </p>
+      <div style="color: black; display: inline;">
+        <input type="radio" id="stypes" name="filter_by" value="software_types" onclick="handleRadio(this);" style="margin-left: 30px;" <% if @params["filter_by"].to_s == "software_types" %>checked<% end %>>
+        <label for="stypes">Software Types</label>
+
+        <input type="radio" id="vrecords" name="filter_by" value="vendor_records" onclick="handleRadio(this);" style="margin-left: 30px;" <% if @params["filter_by"].to_s == "vendor_records" %>checked<% end %>>
+        <label for="vrecords">Vendor Records</label>
+
+        <button type="button" class="btn btn-dark clear-filters" <% if @params["filter_by"].nil? %>style="margin-left: 60px; display: none;" <% else %> style="margin-left: 60px; display: inline;" <% end %> onclick="clearFilters()">Clear all filters <i class="fas fa-times"></i></button>
+      </div>
+      <div style="margin-top: 13px;"></div>
+
+      <div id="vendor-record-filter" <% if @params["filter_by"].to_s == "vendor_records" %> style="display: block;" <% else %>style="display: none"<% end %> >
+        <p style="font-size: 17px; color: black; display: inline;">Search/Filter value:
+        <select name="vendor_record_filter" onchange="this.form.submit()">
+            <option value="">None</option>
+            <% @vendor_records.each do |vendor| %>
+              <% if vendor.id.to_s == @params["vendor_record_filter"].to_s %>
+                <option value="<%= vendor.id %>" selected><%= vendor.title %></option>
+              <% else %>
+                <option value="<%= vendor.id %>"><%= vendor.title %></option>
+              <% end %>
+            <% end %>
+          </select>
+      </div>
+      <div id="software-type-filter" <% if @params["filter_by"].to_s == "software_types" %> style="display: block;" <% else %>style="display: none"<% end %> >
+        <p style="font-size: 17px; color: black; display: inline;">Search/Filter value:
+        <select name="software_type_filter" onchange="this.form.submit()">
+            <option value="">None</option>
+            <% @software_types.each do |type| %>
+              <% if type.id.to_s == @params["software_type_filter"].to_s %>
+                <option value="<%= type.id %>" selected><%= type.title %></option>
+              <% else %>
+                <option value="<%= type.id %>"><%= type.title %></option>
+              <% end %>
+            <% end %>
+          </select>
+      </div>
+    </form>
+</div>
+<br/>
+<hr style = "background-color: black; width: 54%;">
+</section>
+
+<% if @softwarerecords_count != 0 %>
+<div class="container animated fadeInLeft" style="margin-bottom: 10rem">
+  <div class="row">
+    <table class="table software-records-table" style="word-break: initial;">
+      <thead>
+        <tr>
+          <th class="text-left" style="padding-left: 20px"><%= sortable "title", "Software Record" %>
+            <% if params[:direction] == "asc" || params[:direction] == nil %>
+              <i class="fa fa-caret-up"></i>
+            <% else %>
+              <i class="fa fa-caret-down"></i>
+            <% end %></th>
+
+            <th class="text-left" style="padding-left: 20px"><%= sortable "priority", "Priority Rating" %>
+              <% if params[:direction] == "asc" || params[:direction] == nil %>
+                <i class="fa fa-caret-up"></i>
+              <% else %>
+                <i class="fa fa-caret-down"></i>
+              <% end %></th>
+
+          <th class="text-left" style="padding-left: 20px"><%= sortable "installed_version", "Current Version" %>
+            <% if params[:direction] == "asc" || params[:direction] == nil %>
+              <i class="fa fa-caret-up"></i>
+            <% else %>
+              <i class="fa fa-caret-down"></i>
+            <% end %></th>
+          <th class="text-left" style="padding-left: 20px"><%= sortable "proposed_version", "Proposed Version" %>
+            <% if params[:direction] == "asc" || params[:direction] == nil %>
+              <i class="fa fa-caret-up"></i>
+            <% else %>
+              <i class="fa fa-caret-down"></i>
+            <% end %></th>
+          <th class="text-left" style="padding-left: 20px"><%= sortable "last_upgrade_date", "Last Upgrade Date" %>
+            <% if params[:direction] == "asc" || params[:direction] == nil %>
+              <i class="fa fa-caret-up"></i>
+            <% else %>
+              <i class="fa fa-caret-down"></i>
+            <% end %></th>
+
+            <th class="text-left" style="padding-left: 20px"><%= sortable "vulnerabilities_reported", "Vulnerabilites Reported" %>
+              <% if params[:direction] == "asc" || params[:direction] == nil %>
+                <i class="fa fa-caret-up"></i>
+              <% else %>
+                <i class="fa fa-caret-down"></i>
+              <% end %></th>
+
+          <% if current_user.role.to_s == "viewer" %>
+            <th class="text-left" style="padding-left: 20px">Actions</th>
+          <% elsif current_user.role.to_s == "owner" %>
+            <th colspan="2" class="text-left" style="padding-left: 20px">Actions</th>
+          <% else %>
+            <th colspan="3" class="text-left" style="padding-left: 20px">Actions</th>
+          <% end %>
+        </tr>
+      </thead>
+
+      <tbody>
+        <% @software_records.each do |software_record| %>
+          <tr>
+            <td style="padding-left: 40px;"><%= software_record.title %></td>
+            <td><%= software_record.priority %></td>
+            <td><%= software_record.installed_version %></td>
+            <td><%= software_record.proposed_version %></td>
+            <td><%= software_record.last_upgrade_date %></td>
+            <td><%= software_record.vulnerabilities_reported %></td>
+            <% if current_user.role.to_s == "viewer" %>
+              <td><%= link_to 'View', software_record , { :class => "btn btn-success action-btn" }%></td>
+            <% elsif current_user.role.to_s == "owner" %>
+              <td><%= link_to 'View', software_record , { :class => "btn btn-success action-btn" }%></td>
+              <td><%= link_to 'Edit', edit_software_record_path(software_record), { :class => "btn btn-primary action-btn" } %></td>
+            <% else %>
+              <td><%= link_to 'View', software_record , { :class => "btn btn-success action-btn" }%></td>
+              <td><%= link_to 'Edit', edit_software_record_path(software_record), { :class => "btn btn-primary action-btn" } %></td>
+              <td><%= link_to 'Delete', software_record, method: :delete, :class => "btn btn-danger action-btn", data: { confirm: 'Are you sure?' } %></td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+<% else %>
+<h3 class="text-center">No records found</h3>
+<% end %>

--- a/app/views/software_records/show.html.erb
+++ b/app/views/software_records/show.html.erb
@@ -35,6 +35,13 @@
           <a class="nav-link" id="upgrade-history-tab" data-toggle="tab" href="#upgrade-history" role="tab" aria-controls="contact"
             aria-selected="false">Upgrade History</a>
         </li>
+  
+        <li class="nav-item">
+          <a class="nav-link" id="maintenance-log-tab" data-toggle="tab" href="#maintenance-log" role="tab" aria-controls="contact"
+            aria-selected="false">Maintenance Log</a>
+        </li>
+
+
       </ul>
 
       <div class="tab-content" id="SoftwareRecordsTabContent">
@@ -51,6 +58,9 @@
       <div class="tab-pane fade" id="upgrade-history" role="tabpanel">
         <%= render 'upgrade_history' %>
       </div>
+
+      <div class="tab-pane fade" id="maintenance-log" role="tabpanel">
+        <%= render 'maintenance_log' %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   resources :software_records
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'front#index'
+  get 'list_upgrades' => 'software_records#list_upgrades'
   get 'about', to: 'front#about'
   get 'contact', to: 'front#contact'
   get 'request/new', to: 'front#new'

--- a/db/migrate/20230530213413_add_maintenance_to_software_records.rb
+++ b/db/migrate/20230530213413_add_maintenance_to_software_records.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddMaintenanceToSoftwareRecords < ActiveRecord::Migration[5.2]
+  def change
+    add_column :software_records, :service, :string
+    add_column :software_records, :installed_version, :string
+    add_column :software_records, :latest_version, :string
+    add_column :software_records, :proposed_version, :string
+    add_column :software_records, :last_upgrade_date, :date
+    add_column :software_records, :upgrade_available, :boolean
+    add_column :software_records, :vulnerabilities_reported, :boolean
+    add_column :software_records, :vulnerabilities_fixed, :boolean
+    add_column :software_records, :bug_fixes, :boolean
+    add_column :software_records, :new_features, :boolean
+    add_column :software_records, :breaking_changes, :boolean
+    add_column :software_records, :end_of_life, :boolean
+    add_column :software_records, :priority, :integer
+    add_column :software_records, :upgrade_status, :string
+    add_column :software_records, :who, :string
+    add_column :software_records, :semester, :string
+    add_column :software_records, :upgrade_docs, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_230_503_170_052) do
+ActiveRecord::Schema.define(version: 20_230_530_213_413) do
   create_table "file_uploads", force: :cascade do |t|
     t.string "attachment"
     t.datetime "created_at", null: false
@@ -70,6 +70,23 @@ ActiveRecord::Schema.define(version: 20_230_503_170_052) do
     t.string "monitor_errors"
     t.string "authentication_type"
     t.text "admin_users"
+    t.string "service"
+    t.string "installed_version"
+    t.string "latest_version"
+    t.string "proposed_version"
+    t.date "last_upgrade_date"
+    t.boolean "upgrade_available"
+    t.boolean "vulnerabilities_reported"
+    t.boolean "vulnerabilities_fixed"
+    t.boolean "bug_fixes"
+    t.boolean "new_features"
+    t.boolean "breaking_changes"
+    t.boolean "end_of_life"
+    t.integer "priority"
+    t.string "upgrade_status"
+    t.string "who"
+    t.string "semester"
+    t.string "upgrade_docs"
     t.index ["hosting_environment_id"], name: "index_software_records_on_hosting_environment_id"
     t.index ["software_type_id"], name: "index_software_records_on_software_type_id"
     t.index ["status_id"], name: "index_software_records_on_status_id"

--- a/spec/controllers/software_records_controller_spec.rb
+++ b/spec/controllers/software_records_controller_spec.rb
@@ -66,7 +66,24 @@ RSpec.describe SoftwareRecordsController, type: :controller do
       tech_leads: ['Lead 1'],
       product_owners: %w[Owner1 Owner2],
       admin_users: %w[Admin1 Admin2],
-      hosting_environment_id: HostingEnvironment.first.id
+      hosting_environment_id: HostingEnvironment.first.id,
+      service: 'App Service',
+      installed_version: '4.5',
+      latest_version: '4.6',
+      proposed_version: '4.4',
+      last_upgrade_date: '2020-02-02',
+      upgrade_available: true,
+      vulnerabilities_reported: true,
+      vulnerabilities_fixed: true,
+      bug_fixes: true,
+      new_features: true,
+      breaking_changes: true,
+      end_of_life: true,
+      priority: '10',
+      upgrade_status: 'Review',
+      who: 'Test Admin',
+      semester: 'Fall Quarter 2023',
+      upgrade_docs: 'www.example.com'
     }
   end
 
@@ -120,6 +137,15 @@ RSpec.describe SoftwareRecordsController, type: :controller do
       expect(response.body).to have_content('Owner2')
       expect(response.body).to have_content('Admin1')
       expect(response.body).to have_content('Admin2')
+      expect(response.body).to have_content('App Service')
+      expect(response.body).to have_content('4.5')
+      expect(response.body).to have_content('4.6')
+      expect(response.body).to have_content('4.4')
+      expect(response.body).to have_content('2020-02-02')
+      expect(response.body).to have_content('true')
+      expect(response.body).to have_content('10')
+      expect(response.body).to have_content('Review')
+      expect(response.body).to have_content('Fall Quarter 2023')
     end
   end
 
@@ -177,7 +203,24 @@ RSpec.describe SoftwareRecordsController, type: :controller do
           developers: %w[Developer Developer2],
           tech_leads: %w[Lead Lead2],
           product_owners: %w[Owner Owner2],
-          admin_users: %w[Admin Admin2]
+          admin_users: %w[Admin Admin2],
+          service: 'App Service',
+          installed_version: '4.5',
+          latest_version: '4.6',
+          proposed_version: '4.4',
+          last_upgrade_date: '2020-02-02',
+          upgrade_available: true,
+          vulnerabilities_reported: true,
+          vulnerabilities_fixed: true,
+          bug_fixes: true,
+          new_features: true,
+          breaking_changes: true,
+          end_of_life: true,
+          priority: '10',
+          upgrade_status: 'Review',
+          who: 'Test Admin',
+          semester: 'Fall Quarter 2023',
+          upgrade_docs: 'www.example.com'
         }
       end
 
@@ -196,6 +239,16 @@ RSpec.describe SoftwareRecordsController, type: :controller do
         expect(software_record.product_owners).to have_content('Owner2')
         expect(software_record.admin_users).to have_content('Admin')
         expect(software_record.admin_users).to have_content('Admin2')
+        expect(software_record.service).to have_content('App Service')
+        expect(software_record.installed_version).to have_content('4.5')
+        expect(software_record.latest_version).to have_content('4.6')
+        expect(software_record.proposed_version).to have_content('4.4')
+        expect(software_record.last_upgrade_date).to have_content('2020-02-02')
+        expect(software_record.upgrade_available).to have_content('true')
+        expect(software_record.priority).to have_content('10')
+        expect(software_record.upgrade_status).to have_content('Review')
+        expect(software_record.semester).to have_content('Fall Quarter 2023')
+        expect(software_record.upgrade_docs).to have_content('www.example.com')
       end
 
       it 'redirects to the software_record' do
@@ -277,7 +330,24 @@ RSpec.describe SoftwareRecordsController, type: :controller do
       developers: %w[Tester Random],
       tech_leads: ['Lead 1'],
       product_owners: %w[Owner1 Owner2],
-      admin_users: %w[Admin1 Admin2]
+      admin_users: %w[Admin1 Admin2],
+      service: 'App Service',
+      installed_version: '4.5',
+      latest_version: '4.6',
+      proposed_version: '4.4',
+      last_upgrade_date: '2020-02-02',
+      upgrade_available: true,
+      vulnerabilities_reported: true,
+      vulnerabilities_fixed: true,
+      bug_fixes: true,
+      new_features: true,
+      breaking_changes: true,
+      end_of_life: true,
+      priority: '10',
+      upgrade_status: 'Review',
+      who: 'Test Admin',
+      semester: 'Fall Quarter 2023',
+      upgrade_docs: 'www.example.com'
     }
   end
 
@@ -329,6 +399,15 @@ RSpec.describe SoftwareRecordsController, type: :controller do
       expect(response.body).to have_content('Owner2')
       expect(response.body).to have_content('Admin1')
       expect(response.body).to have_content('Admin2')
+      expect(response.body).to have_content('App Service')
+      expect(response.body).to have_content('4.5')
+      expect(response.body).to have_content('4.6')
+      expect(response.body).to have_content('4.4')
+      expect(response.body).to have_content('2020-02-02')
+      expect(response.body).to have_content('true')
+      expect(response.body).to have_content('10')
+      expect(response.body).to have_content('Review')
+      expect(response.body).to have_content('Fall Quarter 2023')
     end
   end
 
@@ -386,7 +465,24 @@ RSpec.describe SoftwareRecordsController, type: :controller do
           developers: %w[Developer Developer2],
           tech_leads: %w[Lead Lead2],
           product_owners: %w[Owner Owner2],
-          admin_users: %w[Admin Admin2]
+          admin_users: %w[Admin Admin2],
+          service: 'App Service',
+          installed_version: '4.5',
+          latest_version: '4.6',
+          proposed_version: '4.4',
+          last_upgrade_date: '2020-02-02',
+          upgrade_available: true,
+          vulnerabilities_reported: true,
+          vulnerabilities_fixed: true,
+          bug_fixes: true,
+          new_features: true,
+          breaking_changes: true,
+          end_of_life: true,
+          priority: '10',
+          upgrade_status: 'Review',
+          who: 'Test Admin',
+          semester: 'Fall Quarter 2023',
+          upgrade_docs: 'www.example.com'
         }
       end
 
@@ -405,6 +501,16 @@ RSpec.describe SoftwareRecordsController, type: :controller do
         expect(software_record.product_owners).to have_content('Owner2')
         expect(software_record.admin_users).to have_content('Admin')
         expect(software_record.admin_users).to have_content('Admin2')
+        expect(software_record.service).to have_content('App Service')
+        expect(software_record.installed_version).to have_content('4.5')
+        expect(software_record.latest_version).to have_content('4.6')
+        expect(software_record.proposed_version).to have_content('4.4')
+        expect(software_record.last_upgrade_date).to have_content('2020-02-02')
+        expect(software_record.upgrade_available).to have_content('true')
+        expect(software_record.priority).to have_content('10')
+        expect(software_record.upgrade_status).to have_content('Review')
+        expect(software_record.semester).to have_content('Fall Quarter 2023')
+        expect(software_record.upgrade_docs).to have_content('www.example.com')
       end
 
       it 'redirects to the software_record' do
@@ -485,7 +591,24 @@ RSpec.describe SoftwareRecordsController, type: :controller do
       developers: %w[Tester Random],
       tech_leads: ['Lead 1'],
       product_owners: %w[Owner1 Owner2],
-      admin_users: %w[Admin1 Admin2]
+      admin_users: %w[Admin1 Admin2],
+      service: 'App Service',
+      installed_version: '4.5',
+      latest_version: '4.6',
+      proposed_version: '4.4',
+      last_upgrade_date: '2020-02-02',
+      upgrade_available: true,
+      vulnerabilities_reported: true,
+      vulnerabilities_fixed: true,
+      bug_fixes: true,
+      new_features: true,
+      breaking_changes: true,
+      end_of_life: true,
+      priority: '10',
+      upgrade_status: 'Review',
+      who: 'Test Admin',
+      semester: 'Fall Quarter 2023',
+      upgrade_docs: 'www.example.com'
     }
   end
 
@@ -537,6 +660,15 @@ RSpec.describe SoftwareRecordsController, type: :controller do
       expect(response.body).to have_content('Owner2')
       expect(response.body).to have_content('Admin1')
       expect(response.body).to have_content('Admin2')
+      expect(response.body).to have_content('App Service')
+      expect(response.body).to have_content('4.5')
+      expect(response.body).to have_content('4.6')
+      expect(response.body).to have_content('4.4')
+      expect(response.body).to have_content('2020-02-02')
+      expect(response.body).to have_content('true')
+      expect(response.body).to have_content('10')
+      expect(response.body).to have_content('Review')
+      expect(response.body).to have_content('Fall Quarter 2023')
     end
   end
 
@@ -594,7 +726,24 @@ RSpec.describe SoftwareRecordsController, type: :controller do
           developers: %w[Developer Developer2],
           tech_leads: %w[Lead Lead2],
           product_owners: %w[Owner Owner2],
-          admin_users: %w[Admin Admin2]
+          admin_users: %w[Admin Admin2],
+          service: 'App Service',
+          installed_version: '4.5',
+          latest_version: '4.6',
+          proposed_version: '4.4',
+          last_upgrade_date: '2020-02-02',
+          upgrade_available: true,
+          vulnerabilities_reported: true,
+          vulnerabilities_fixed: true,
+          bug_fixes: true,
+          new_features: true,
+          breaking_changes: true,
+          end_of_life: true,
+          priority: '10',
+          upgrade_status: 'Review',
+          who: 'Test Admin',
+          semester: 'Fall Quarter 2023',
+          upgrade_docs: 'www.example.com'
         }
       end
 
@@ -613,6 +762,16 @@ RSpec.describe SoftwareRecordsController, type: :controller do
         expect(software_record.product_owners).to have_content('Owner2')
         expect(software_record.admin_users).to have_content('Admin')
         expect(software_record.admin_users).to have_content('Admin2')
+        expect(software_record.service).to have_content('App Service')
+        expect(software_record.installed_version).to have_content('4.5')
+        expect(software_record.latest_version).to have_content('4.6')
+        expect(software_record.proposed_version).to have_content('4.4')
+        expect(software_record.last_upgrade_date).to have_content('2020-02-02')
+        expect(software_record.upgrade_available).to have_content('true')
+        expect(software_record.priority).to have_content('10')
+        expect(software_record.upgrade_status).to have_content('Review')
+        expect(software_record.semester).to have_content('Fall Quarter 2023')
+        expect(software_record.upgrade_docs).to have_content('www.example.com')
       end
 
       it 'redirects to the software_record' do
@@ -694,7 +853,24 @@ RSpec.describe SoftwareRecordsController, type: :controller do
       developers: %w[Tester Random],
       tech_leads: ['Lead 1'],
       product_owners: %w[Owner1 Owner2],
-      admin_users: %w[Admin1 Admin2]
+      admin_users: %w[Admin1 Admin2],
+      service: 'App Service',
+      installed_version: '4.5',
+      latest_version: '4.6',
+      proposed_version: '4.4',
+      last_upgrade_date: '2020-02-02',
+      upgrade_available: true,
+      vulnerabilities_reported: true,
+      vulnerabilities_fixed: true,
+      bug_fixes: true,
+      new_features: true,
+      breaking_changes: true,
+      end_of_life: true,
+      priority: '10',
+      upgrade_status: 'Review',
+      who: 'Test Admin',
+      semester: 'Fall Quarter 2023',
+      upgrade_docs: 'www.example.com'
     }
   end
 
@@ -746,6 +922,15 @@ RSpec.describe SoftwareRecordsController, type: :controller do
       expect(response.body).to have_content('Owner2')
       expect(response.body).to have_content('Admin1')
       expect(response.body).to have_content('Admin2')
+      expect(response.body).to have_content('App Service')
+      expect(response.body).to have_content('4.5')
+      expect(response.body).to have_content('4.6')
+      expect(response.body).to have_content('4.4')
+      expect(response.body).to have_content('2020-02-02')
+      expect(response.body).to have_content('true')
+      expect(response.body).to have_content('10')
+      expect(response.body).to have_content('Review')
+      expect(response.body).to have_content('Fall Quarter 2023')
     end
   end
 
@@ -803,7 +988,24 @@ RSpec.describe SoftwareRecordsController, type: :controller do
           developers: %w[Developer Developer2],
           tech_leads: %w[Lead Lead2],
           product_owners: %w[Owner Owner2],
-          admin_users: %w[Admin Admin2]
+          admin_users: %w[Admin Admin2],
+          service: 'App Service',
+          installed_version: '4.5',
+          latest_version: '4.6',
+          proposed_version: '4.4',
+          last_upgrade_date: '2020-02-02',
+          upgrade_available: true,
+          vulnerabilities_reported: true,
+          vulnerabilities_fixed: true,
+          bug_fixes: true,
+          new_features: true,
+          breaking_changes: true,
+          end_of_life: true,
+          priority: '10',
+          upgrade_status: 'Review',
+          who: 'Test Admin',
+          semester: 'Fall Quarter 2023',
+          upgrade_docs: 'www.example.com'
         }
       end
 
@@ -822,6 +1024,16 @@ RSpec.describe SoftwareRecordsController, type: :controller do
         expect(software_record.product_owners).to have_content('Owner2')
         expect(software_record.admin_users).to have_content('Admin')
         expect(software_record.admin_users).to have_content('Admin2')
+        expect(software_record.service).to have_content('App Service')
+        expect(software_record.installed_version).to have_content('4.5')
+        expect(software_record.latest_version).to have_content('4.6')
+        expect(software_record.proposed_version).to have_content('4.4')
+        expect(software_record.last_upgrade_date).to have_content('2020-02-02')
+        expect(software_record.upgrade_available).to have_content('true')
+        expect(software_record.priority).to have_content('10')
+        expect(software_record.upgrade_status).to have_content('Review')
+        expect(software_record.semester).to have_content('Fall Quarter 2023')
+        expect(software_record.upgrade_docs).to have_content('www.example.com')
       end
 
       it 'redirects to the software_record' do

--- a/spec/routing/software_records_routing_spec.rb
+++ b/spec/routing/software_records_routing_spec.rb
@@ -35,5 +35,9 @@ RSpec.describe SoftwareRecordsController, type: :routing do
     it 'routes to #destroy' do
       expect(delete: '/software_records/1').to route_to('software_records#destroy', id: '1')
     end
+
+    it 'routes to #list_upgrades' do
+      expect(get: '/list_upgrades').to route_to('software_records#list_upgrades')
+    end
   end
 end

--- a/spec/views/software_records/edit.html.erb_spec.rb
+++ b/spec/views/software_records/edit.html.erb_spec.rb
@@ -29,7 +29,24 @@ RSpec.describe 'software_records/edit', type: :view do
                                                   software_type_id: SoftwareType.first.id,
                                                   authentication_type: 'DUO',
                                                   vendor_record_id: VendorRecord.first.id,
-                                                  created_by: 'Test User'
+                                                  created_by: 'Test User',
+                                                  service: 'App Service',
+                                                  installed_version: '4.5',
+                                                  latest_version: '4.6',
+                                                  proposed_version: '4.4',
+                                                  last_upgrade_date: '2020-02-02',
+                                                  upgrade_available: true,
+                                                  vulnerabilities_reported: true,
+                                                  vulnerabilities_fixed: true,
+                                                  bug_fixes: true,
+                                                  new_features: true,
+                                                  breaking_changes: true,
+                                                  end_of_life: true,
+                                                  priority: '10',
+                                                  upgrade_status: 'Review',
+                                                  who: 'Test Admin',
+                                                  semester: 'Fall Quarter 2023',
+                                                  upgrade_docs: 'www.example.com'
                                                 ))
     session[:previous] = dashboard_path
   end
@@ -84,6 +101,21 @@ RSpec.describe 'software_records/edit', type: :view do
       assert_select 'input[name=?]', 'software_record[track_uptime]'
       assert_select 'input[name=?]', 'software_record[monitor_health]'
       assert_select 'input[name=?]', 'software_record[monitor_errors]'
+    end
+  end
+
+  it 'renders the maintenance log form' do
+    render
+    assert_select 'form[action=?][method=?]', software_record_path(@software_record), 'post' do
+      assert_select 'input[name=?]', 'software_record[service]'
+      assert_select 'input[name=?]', 'software_record[installed_version]'
+      assert_select 'input[name=?]', 'software_record[proposed_version]'
+      assert_select 'input[name=?]', 'software_record[monitor_errors]'
+      assert_select 'input[name=?]', 'software_record[priority]'
+      assert_select 'input[name=?]', 'software_record[upgrade_status]'
+      assert_select 'input[name=?]', 'software_record[who]'
+      assert_select 'input[name=?]', 'software_record[semester]'
+      assert_select 'input[name=?]', 'software_record[upgrade_docs]'
     end
   end
 end

--- a/spec/views/software_records/list_upgrades.html.erb_spec.rb
+++ b/spec/views/software_records/list_upgrades.html.erb_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'software_records/list_upgrades', type: :view do
+  before(:each) do
+    VendorRecord.create!(
+      id: 311,
+      title: 'Vendor 122',
+      description: 'test vendor'
+    )
+    VendorRecord.create!(
+      id: 411,
+      title: 'Vendor Filter',
+      description: 'test filter vendor'
+    )
+    SoftwareType.create!(
+      id: 111,
+      title: 'Web app',
+      description: 'test software type'
+    )
+    Status.create!(
+      title: 'Test',
+      status_type: 'Design'
+    )
+    HostingEnvironment.create!(
+      title: 'Test Env.',
+      description: 'test env.'
+    )
+    assign(:software_records, [
+             SoftwareRecord.create!(
+               title: 'Title',
+               description: 'MyText',
+               status_id: Status.first.id,
+               hosting_environment_id: HostingEnvironment.first.id,
+               date_implemented: '2020-12-12',
+               vendor_record_id: VendorRecord.first.id,
+               software_type_id: SoftwareType.first.id,
+               created_by: 'Test User',
+               priority: 10
+             ),
+             SoftwareRecord.create!(
+               title: 'Title',
+               description: 'MyText',
+               status_id: Status.first.id,
+               hosting_environment_id: HostingEnvironment.first.id,
+               date_implemented: '2020-12-12',
+               vendor_record_id: VendorRecord.first.id,
+               software_type_id: SoftwareType.first.id,
+               created_by: 'Test User'
+             )
+           ])
+    assign(:vendor_records, VendorRecord.all)
+    assign(:software_types, SoftwareType.all)
+
+    allow(view).to(receive(:user_signed_in?) { true }) && allow(view).to(receive(:current_user) do
+                                                                           FactoryBot.build(:admin)
+                                                                         end)
+  end
+  it 'renders a list of software_records' do
+    render
+    assert_select 'td:nth-child(1)', text: 'Title'.to_s, count: 2
+    expect(rendered).to_not have_text('Status')
+  end
+
+  it 'renders the expected list when filter is applied' do
+    render
+    expect(rendered).to have_text('Vendor Filter')
+  end
+end

--- a/spec/views/software_records/show.html.erb_spec.rb
+++ b/spec/views/software_records/show.html.erb_spec.rb
@@ -44,7 +44,24 @@ RSpec.describe 'software_records/show', type: :view do
                                                   last_record_change: now,
                                                   track_uptime: 'Yes',
                                                   monitor_health: 'Yes',
-                                                  monitor_errors: 'Yes'
+                                                  monitor_errors: 'Yes',
+                                                  service: 'App Service',
+                                                  installed_version: '4.5',
+                                                  latest_version: '4.6',
+                                                  proposed_version: '4.4',
+                                                  last_upgrade_date: '2020-02-02',
+                                                  upgrade_available: true,
+                                                  vulnerabilities_reported: true,
+                                                  vulnerabilities_fixed: true,
+                                                  bug_fixes: true,
+                                                  new_features: true,
+                                                  breaking_changes: true,
+                                                  end_of_life: true,
+                                                  priority: '10',
+                                                  upgrade_status: 'Review',
+                                                  who: 'Test Admin',
+                                                  semester: 'Fall Quarter 2023',
+                                                  upgrade_docs: 'www.example.com'
                                                 ))
     allow(view).to(receive(:user_signed_in?) { true }) && allow(view).to(receive(:current_user) { FactoryBot.build(:viewer) })
     session[:previous] = dashboard_path
@@ -92,5 +109,26 @@ RSpec.describe 'software_records/show', type: :view do
     expect(rendered).to match(/Track uptime/)
     expect(rendered).to match(/Monitor health/)
     expect(rendered).to match(/Monitor errors/)
+  end
+
+  it 'renders maintenance log values' do
+    render
+    expect(rendered).to match(/Name of Service/)
+    expect(rendered).to match(/Current Version/)
+    expect(rendered).to match(/Latest version available/)
+    expect(rendered).to match(/Next Proposed version/)
+    expect(rendered).to match(/Last Upgrade Date/)
+    expect(rendered).to match(/Is there an upgrade available/)
+    expect(rendered).to match(/Are there vulnerabilities reported/)
+    expect(rendered).to match(/Does the new version fix vulnerabilities/)
+    expect(rendered).to match(/Are there bug fixes reported/)
+    expect(rendered).to match(/Are there any new features/)
+    expect(rendered).to match(/Are there any breaking changes/)
+    expect(rendered).to match(/Is this an end of life version/)
+    expect(rendered).to match(/Is this a priority/)
+    expect(rendered).to match(/What is the status/)
+    expect(rendered).to match(/Who is responsible/)
+    expect(rendered).to match(/What semester is this scheduled for/)
+    expect(rendered).to match(/Are there any ugprade links/)
   end
 end


### PR DESCRIPTION
Fixes : #65 and Fixes #277

1. The purpose of this PR is to add the idea of a Maintenance Log to the SoftwareRecord.  
2. You must be an Admin / Manager / Technician to CRUD.
3. This Maintenance Log tab can be found on the SoftwareRecord and contains all of the fields required by INfoSec
4. This Maintenance Log tab can be found on the SoftwareRecord and contains all of the fields required by Change Management.
5. The Maintenance Log displays the following fields from the SoftwareRecord ().
6. This PR creates a Priority List that can be found from the Sidebar Menu.  This priority list is sorted by the Priority field.

Create new issues for

- Add more InfoSec and Change Fields.
- Improve layout on screen.
- Improve testing
- PR to go green under Brakeman
