### PR TITLE
Removes libapps2 from code.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ executors:
 orbs:
   browser-tools: circleci/browser-tools@1.4.7
   coveralls: coveralls/coveralls@1.0.6
+
 jobs:
   build:
     docker:
@@ -39,7 +40,10 @@ jobs:
 
     steps:
  
-      - browser-tools/install-browser-tools
+
+      - browser-tools/install-browser-tools:
+          replace-existing-chrome: true
+
       - checkout
 
       - restore_cache:

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -8,7 +8,7 @@ set :bundle_path, -> { shared_path.join('vendor/bundle') }
 append :linked_dirs, 'tmp', 'log'
 ask(:username, nil)
 ask(:password, nil, echo: false)
-server 'libapps2.libraries.uc.edu', user: fetch(:username), password: fetch(:password), port: 22
+server 'libapps.libraries.uc.edu', user: fetch(:username), password: fetch(:password), port: 22
 ask(:value, 'Have you submitted and received an approved Change Management Request? (Y)')
 if fetch(:value) != 'Y'
   puts "\nDeploy cancelled!"


### PR DESCRIPTION
Make sure to check the .env files for any instance of libapps2.libraries.uc.edu

Fixes #326 