### PR TITLE
Fix Uglififer on Deploy

### DIFF
--- a/app/assets/javascripts/multivalueinputs.js
+++ b/app/assets/javascripts/multivalueinputs.js
@@ -1,12 +1,10 @@
 window.onload = function() {
     window.counts = {
-     
-      developers: window.counts?.developers || 1,
-      tech_leads: window.counts?.tech_leads || 1,
-      departments: window.counts?.departments || 1,
-      product_owners: window.counts?.product_owners || 1,
-      admin_users: window.counts?.admin_users || 1
-    
+        developers: (window.counts && window.counts.developers) || 1,
+        tech_leads: (window.counts && window.counts.tech_leads) || 1,
+        departments: (window.counts && window.counts.departments) || 1,
+        product_owners: (window.counts && window.counts.product_owners) || 1,
+        admin_users: (window.counts && window.counts.admin_users) || 1
     };
 };
 


### PR DESCRIPTION
When I attempted to deploy the updated QA branch to libappstest.libriares.uc.edu, I ran into a problem during the deploying of the javascript assets.  Uglifier, which is used to minify JavaScript, does not support optional chaining (?.) which is an ES2020 feature. 

I needed to change the way the chaining was done.

I tested the branch by deploying it directly to libappstest and the deploy was successfull.