### PR TITLE
LIBAPPPORT-66 Update .bundler-audit.yml to pass nokogiri 1.16, add .env.production to .gitignore

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -6,5 +6,7 @@ ignore:
   - CVE-2024-53986
   - CVE-2024-53985
 
-  # Nokogiri - servers don't have compatible GLIBC
+  # Nokogiri - servers don't have compatible GLIBC. Wants
+  # an upgrade to version 1.18.4.
   - GHSA-vvfq-8hwr-qm4m
+  - GHSA-mrxw-mxhj-p664

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ yarn.lock
 
 #Ignore Rubymine files
 .idea/
+
+# Ignore .env.production and .env.production.local
+.env.production
+.env.production.local


### PR DESCRIPTION
Nokogiri had another bundler-udit issue that needed to be ignored in the `.bundler-audit.yml` file.

Also adds `.env.production` and `.env.production.local` to .gitignore to prevent accidental commits of sensitive information.