### PR TITLE
LIBAPPORT-55-Removes presence requirement for fields in Change Request.

### DIFF
--- a/app/models/change_request.rb
+++ b/app/models/change_request.rb
@@ -2,9 +2,5 @@
 
 class ChangeRequest < ApplicationRecord
   validates :change_title, presence: true
-  validates :application_pages, presence: true
-  validates :number_roles, presence: true
-  validates :authentication_needed, presence: true
-  validates :custom_error_pages, presence: true
   belongs_to :software_record
 end

--- a/spec/models/change_request_spec.rb
+++ b/spec/models/change_request_spec.rb
@@ -5,10 +5,10 @@ require 'rails_helper'
 RSpec.describe ChangeRequest, type: :model do
   describe 'validations' do
     it { should validate_presence_of(:change_title) }
-    it { should validate_presence_of(:application_pages) }
-    it { should validate_presence_of(:number_roles) }
-    it { should validate_presence_of(:authentication_needed) }
-    it { should validate_presence_of(:custom_error_pages) }
+    it { should_not validate_presence_of(:application_pages) }
+    it { should_not validate_presence_of(:number_roles) }
+    it { should_not validate_presence_of(:authentication_needed) }
+    it { should_not validate_presence_of(:custom_error_pages) }
   end
 
   describe 'associations' do


### PR DESCRIPTION
We don't need validators on these fields.  They are not required fields.

validates :application_pages, presence: true
  validates :number_roles, presence: true
  validates :authentication_needed, presence: true
  validates :custom_error_pages, presence: true