### PR TITLE
LIBAPPPORT-72 Expanded .gitignore rules to ignore additional SQLite runtime files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,10 @@
 /.bundle
 
 # Ignore the default SQLite database.
-/db/*.sqlite3
-/db/*.sqlite3-journal
+/db/*.sqlite3           # Default SQLite database files
+/db/*.sqlite3-journal   # Journal files (pre-WAL mode)
+/db/*.sqlite3-wal       # Write-Ahead Log (WAL) files
+/db/*.sqlite3-shm       # Shared Memory files
 
 # Ignore all logfiles and tempfiles.
 /log/*


### PR DESCRIPTION
Expanded .gitignore rules to ignore additional SQLite runtime files (-wal and -shm) that are created in "Write-Ahead Logging" mode. This prevents these environment-specific artifacts from appearing in git status or being accidentally committed.

## Testing Instructions for Reviewer
To confirm no SQLite database artifacts were previously committed, run:

`git ls-files | grep '\.sqlite3'`

Expected result: no output