### PR TITLE
Update CHANGELOG for v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+2.0.0 5/29/2026
+
+* Implements Single Sign-On (SSO) via Shibboleth
+  * Adds Shibboleth session handling and user provisioning
+  * Adds EPPN field to users
+  * Removes local Devise registration, password reset, and signup mailer
+* Upgrades Rails to 8.1.3
+* Upgrades Rack to 3.2
+* Updates Ruby to 3.4.9
+* Updates Nokogiri to 1.19
+* Updates Node to 24
+* Updates Capistrano and Selenium dependencies
+* Removes unused Docker development tooling
+* Removes unused Application Cable boilerplate
+* Creates dev users only in the development environment
+* Bundle and yarn updates; adds bundler-audit to the GitHub workflow
+* Bug Fixes
+  * Fixes multi-value "add more" fields
+
 1.7.1 2/13/2026
 
 * Updates Ruby to 3.4.7

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,7 +3,7 @@
 require 'byebug'
 
 # config valid for current version and patch releases of Capistrano
-lock '~> 3.19.2'
+lock '~> 3.20.1'
 
 set :application, 'application_portfolio'
 set :repo_url, 'https://github.com/uclibs/application_portfolio.git'


### PR DESCRIPTION
This PR only updates the CHANGELOG.  Here is a summary of the changes

## Summary

Release **v2.0.0**. Cuts the next release off `qa`, adding the `2.0.0` CHANGELOG entry and the `v2.0.0` tag. This rolls up everything since `v1.7.0` (the version currently in production) into a single major release.

This is a **major** version bump because it changes authentication behavior (SSO replaces local self-registration/password reset) and jumps Rails by two major versions.

### Highlights
- **Single Sign-On (SSO) via Shibboleth** — adds Shibboleth session handling, user provisioning, and an EPPN field; **removes** local Devise registration, password-reset, and signup-mailer flows.
- **Rails `7.2.2` → `8.1.3`** (two major versions).
- **Rack `2.2` → `3.2`** (major version).
- Ruby `3.4.7` → `3.4.9`, Nokogiri `1.16` → `1.19`, Node 24.
- Removes unused Docker development tooling and Application Cable boilerplate.
- Creates dev users only in the development environment.
- Bundle/yarn updates; adds bundler-audit to the GitHub workflow.
- Bug fix: multi-value "add more" fields.

## Deployment notes

- **Production is currently on `v1.7.0`**, not `v1.7.1`. The `v1.7.1` tag (Ruby 3.4.7 bump) was created but never merged to `main` or deployed.
- **We are deploying `v2.0.0` instead of `v1.7.1`.** `v1.7.1`'s changes are already included in `v2.0.0`, so `1.7.1` will be skipped in production — we go straight from `1.7.0` to `2.0.0`.
- Because authentication moves to SSO, confirm Shibboleth is configured on the production host before/at deploy time.

## Test plan

- [ ] CI passes (RuboCop + RSpec) on `release-2.0.0`
- [ ] SSO login works against the production Shibboleth IdP
- [ ] Existing users resolve correctly via EPPN; new users are provisioned on first login
- [ ] Local Devise registration/password-reset routes are gone (no broken links)
- [ ] Smoke test core flows: dashboard, software record CRUD, change requests, export
- [ ] Run `db:migrate` (adds EPPN column) and verify schema
- [ ] Confirm `v2.0.0` tag is the deployed revision after release (`current/REVISION`)