### PR TITLE
Upgrade capistrano-bundler to 2.x (LIBAPPO1-95)

### DIFF
--- a/.cursor/rules/code-quality.mdc
+++ b/.cursor/rules/code-quality.mdc
@@ -1,0 +1,49 @@
+---
+description: Code quality standards for Application Portfolio — review changed files before calling work complete
+alwaysApply: true
+---
+
+# Application Portfolio — Code Quality
+
+Apply these standards when reviewing or finishing any code change. The **Definition of Done** rule references this file for the code-review step.
+
+## Review every changed file
+
+Fix findings in the same change set; do not defer.
+
+### Antipatterns
+
+- Fat controllers
+- Business logic in views
+- Callbacks doing too much
+- N+1 queries
+- Rescuing `StandardError` broadly
+- Magic strings/numbers without justification
+
+### Code smells
+
+- Long methods
+- Deep nesting
+- Feature envy
+- Shotgun edits
+- Dead code left behind
+
+### Naming
+
+Names should reveal intent. Rename unclear variables, methods, and specs (`describe` / `context` / `it`).
+
+### Duplication
+
+Extract shared logic only when it reduces real duplication. Match existing project style; do not over-abstract.
+
+### Test coverage
+
+New or changed behavior must have **RSpec** coverage (`spec/**/*_spec.rb`). Prefer unit tests (models, services, helpers, controllers, mailers). Mirror existing spec style (FactoryBot, `type: :controller`, etc.).
+
+### Comments on touched files
+
+Update comments on **every file you touch**:
+
+- Keep comments accurate after the change (remove or rewrite stale or misleading text).
+- Document non-obvious behavior, configuration, or trade-offs (especially in deploy config, initializers, and environment files).
+- Do not add comments that restate what the code already says clearly.

--- a/.cursor/rules/definition-of-done.mdc
+++ b/.cursor/rules/definition-of-done.mdc
@@ -1,5 +1,5 @@
 ---
-description: Definition of done for Application Portfolio — review, RuboCop, RSpec before finishing any code change
+description: Definition of done for Application Portfolio — code quality, RuboCop, RSpec before finishing any code change
 alwaysApply: true
 ---
 
@@ -7,17 +7,9 @@ alwaysApply: true
 
 No code change is **done** until all steps below pass. Run them in order; do not skip or ask the user to run them instead.
 
-## 1. Code review (before calling work complete)
+## 1. Code quality review
 
-Review every changed file for:
-
-- **Antipatterns** — fat controllers, business logic in views, callbacks doing too much, N+1 queries, rescuing `StandardError` broadly, magic strings/numbers without justification
-- **Code smells** — long methods, deep nesting, feature envy, shotgun edits, dead code left behind
-- **Naming** — names should reveal intent; rename unclear variables, methods, and specs (`describe`/`context`/`it`)
-- **Duplication** — extract shared logic only when it reduces real duplication; match existing project style (do not over-abstract)
-- **Test coverage** — new or changed behavior must have **RSpec** coverage (`spec/**/*_spec.rb`). Prefer unit tests (models, services, helpers, controllers, mailers). Mirror existing spec style (FactoryBot, `type: :controller`, etc.)
-
-Fix review findings in the same change set; do not defer.
+Follow **`.cursor/rules/code-quality.mdc`** — review every changed file for antipatterns, smells, naming, duplication, test coverage, and updated comments. Fix findings in the same change set.
 
 ## 2. RuboCop (required, no rule evasion)
 
@@ -51,7 +43,7 @@ bundle exec rspec
 
 Before reporting done to the user:
 
-- [ ] Reviewed for antipatterns, smells, naming, duplication
+- [ ] Code quality review per `code-quality.mdc` (including comments on touched files)
 - [ ] New/changed behavior covered by RSpec
 - [ ] `bundle exec rubocop` passes with no new disables/ignores
 - [ ] `bundle exec rspec` passes (or documented scope if user-limited)

--- a/Gemfile
+++ b/Gemfile
@@ -103,7 +103,8 @@ end
 
 group :development do
   gem 'capistrano', '~> 3.20'
-  gem 'capistrano-bundler', '~> 1.6', require: false
+  # 2.x uses `bundler:config` (bundle config --local) before install; see config/deploy.rb.
+  gem 'capistrano-bundler', '~> 2.2', require: false
   gem 'capistrano-rails', '~> 1.4', require: false
   gem 'capistrano-rvm', require: false
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,7 +104,7 @@ GEM
       i18n
       rake (>= 10.0.0)
       sshkit (>= 1.9.0)
-    capistrano-bundler (1.6.0)
+    capistrano-bundler (2.2.0)
       capistrano (~> 3.1)
     capistrano-rails (1.7.0)
       capistrano (~> 3.1)
@@ -465,7 +465,7 @@ DEPENDENCIES
   bundler-audit
   byebug
   capistrano (~> 3.20)
-  capistrano-bundler (~> 1.6)
+  capistrano-bundler (~> 2.2)
   capistrano-rails (~> 1.4)
   capistrano-rvm
   capybara (>= 2.15)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -8,6 +8,13 @@ lock '~> 3.20.1'
 set :application, 'application_portfolio'
 set :repo_url, 'https://github.com/uclibs/application_portfolio.git'
 
+# Written by capistrano-bundler 2.x during `bundler:config`, before `bundle install`.
+# deployment: frozen Gemfile.lock, no dev/test groups on the server.
+# force_ruby_platform: lockfile includes platform-specific native gems (nokogiri,
+# sqlite3, ffi) from Mac dev machines and CI; Linux deploy hosts must install
+# the generic ruby-platform gems and compile on the server (see LIBAPPO1-80).
+set :bundle_config, { deployment: true, force_ruby_platform: true }
+
 task :shared_db do
   on roles(:all) do
     execute "mkdir -p #{fetch(:deploy_to)}/shared/db/ && touch #{fetch(:deploy_to)}/shared/db/development.sqlite3"
@@ -23,11 +30,13 @@ task :start_local do
   end
 end
 
+# Runs on QA and production after deploy:updating, before bundler:config/install.
+# Bundle path, groups, deployment, and force_ruby_platform are handled by
+# capistrano-bundler (see :bundle_config above).
 task :init_qp do
   on roles(:all) do
+    # Must run before capistrano-bundler's bundler:install on hosts without a current Bundler.
     execute 'gem install --user-install bundler'
-    execute "cd #{fetch(:release_path)} && bundle config path 'vendor/bundle' --local"
-    execute "cd #{fetch(:release_path)} && bundle config set force_ruby_platform true --local"
     execute "mkdir -p #{fetch(:deploy_to)}/static"
     execute "cp #{fetch(:deploy_to)}/static/.env.production #{fetch(:release_path)}/ || true"
   end

--- a/config/deploy/local.rb
+++ b/config/deploy/local.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+# Local Capistrano deploy to localhost (development SQLite, no init_qp).
+
 set :rails_env, :development
-set :bundle_without, %w[production test].join(' ')
+# Colon-separated groups; required by capistrano-bundler 2.x / Bundler 2.
+set :bundle_without, %w[production test].join(':')
 set :branch, 'qa'
 set :default_env, path: '$PATH:/usr/local/bin'
 append :linked_files, 'db/development.sqlite3'

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+# Production server (libapps.libraries.uc.edu)
+
 set :rails_env, :production
-set :bundle_without, %w[development test].join(' ')
+# Colon-separated groups; required by capistrano-bundler 2.x / Bundler 2.
+set :bundle_without, %w[development test].join(':')
 set :branch, 'main'
 set :default_env, path: '$PATH:/usr/local/bin'
+# Shared across releases; written by capistrano-bundler's bundler:config.
 set :bundle_path, -> { shared_path.join('vendor/bundle') }
 append :linked_dirs, 'tmp', 'log'
 ask(:username, nil)

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
+# QA server (libappstest.libraries.uc.edu)
+
 set :rails_env, :production
-set :bundle_without, %w[development test].join(' ')
+# Colon-separated groups; required by capistrano-bundler 2.x / Bundler 2.
+set :bundle_without, %w[development test].join(':')
 set :branch, 'qa'
 set :default_env, path: '$PATH:/usr/local/bin'
+# Shared across releases; written by capistrano-bundler's bundler:config.
 set :bundle_path, -> { shared_path.join('vendor/bundle') }
 append :linked_dirs, 'tmp', 'log'
 ask(:username, nil)


### PR DESCRIPTION
## Summary

Upgrades **capistrano-bundler 1.6 → 2.2** (LIBAPPO1-95). v2 uses a `bundler:config` step (`bundle config --local`) before `bundle install`, replacing deprecated Bundler 2 flags (`--path`, `--deployment`, `--without`).

- **`config/deploy.rb`** — adds shared `:bundle_config` (`deployment`, `force_ruby_platform`); removes redundant manual bundle config from `init_qp` (Bundler install, static dir, and `.env.production` copy remain).
- **Stage configs** — `bundle_without` now uses colon-separated groups (`development:test`), required by capistrano-bundler 2.x / Bundler 2.
- **Cursor rules** — extracts code quality standards into `code-quality.mdc`; Definition of Done now references that file.

`force_ruby_platform` is preserved (needed for native gems — nokogiri, sqlite3, ffi — on Linux deploy hosts; see LIBAPPO1-80).

## Test plan

- [ ] `bundle exec cap -T` lists `bundler:config` and `bundler:install`
- [ ] **QA deploy succeeds end-to-end** (`cap qa deploy`)
- [ ] On the server after deploy, verify `.bundle/config` includes `path`, `without`, `deployment`, and `force_ruby_platform`
- [ ] No Bundler deprecation warnings in deploy output
- [ ] App boots and core flows work after deploy