### PR TITLE
Reconcile Capistrano Ruby setup: rbenv on servers, drop capistrano-rvm

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -5,15 +5,10 @@ require 'capistrano/deploy'
 require 'capistrano/scm/git'
 install_plugin Capistrano::SCM::Git
 
+# QA/production use rbenv (scripts/check_ruby.sh); no capistrano-rvm plugin.
 require 'capistrano/bundler'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }
-
-task :use_rvm do
-  require 'capistrano/rvm'
-end
-
-task local: :use_rvm

--- a/Gemfile
+++ b/Gemfile
@@ -106,7 +106,6 @@ group :development do
   # 2.x uses `bundler:config` (bundle config --local) before install; see config/deploy.rb.
   gem 'capistrano-bundler', '~> 2.2', require: false
   gem 'capistrano-rails', '~> 1.4', require: false
-  gem 'capistrano-rvm', require: false
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'listen', '~> 3.5'
   gem 'web-console', '>= 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,9 +109,6 @@ GEM
     capistrano-rails (1.7.0)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
     capybara (3.40.0)
       addressable
       matrix
@@ -467,7 +464,6 @@ DEPENDENCIES
   capistrano (~> 3.20)
   capistrano-bundler (~> 2.2)
   capistrano-rails (~> 1.4)
-  capistrano-rvm
   capybara (>= 2.15)
   chartkick (~> 5.2)
   csv

--- a/README.md
+++ b/README.md
@@ -53,13 +53,21 @@ user.save
 ```
 * Deployment instructions
 
-We deploy this application to both qa and production using Capistrano.  You must make an IP tunnel to the deploy from your local workstation.
+We deploy this application to both qa and production using Capistrano. You must be on the library intranet to deploy from your local workstation.
 
 ```bash
-cap qa deploy for qa
-
-cap prod deploy for production
+cap qa deploy          # QA (libappstest)
+cap production deploy  # production (libapps)
 ```
+
+**Ruby version managers on deploy hosts**
+
+| Environment | Host | Ruby manager | Notes |
+|-------------|------|--------------|-------|
+| QA / production | libappstest, libapps | **rbenv** (user `apache`, `/home/apache/.rbenv`) | `scripts/check_ruby.sh` runs on deploy to install the version from `.ruby-version` when missing |
+| Local cap deploy | localhost | **RVM** (via `scripts/start_local.sh` only) | Optional dev workflow; Capistrano does not use the capistrano-rvm gem |
+
+Puma on QA/production is managed by systemd (`puma-appport.service`), not by Capistrano's Ruby plugin.
 
 * Configuration
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -48,6 +48,8 @@ task :start_qp do
   end
 end
 
+# Ensures the Ruby version in .ruby-version is installed via rbenv on QA/production.
+# Deploy hosts use rbenv under the apache user (/home/apache/.rbenv); see README.
 task :ruby_update_check do
   on roles(:all) do
     execute "cd #{fetch(:release_path)}/ && chmod a+x scripts/* && source scripts/check_ruby.sh"

--- a/config/deploy/local.rb
+++ b/config/deploy/local.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 # Local Capistrano deploy to localhost (development SQLite, no init_qp).
+# App server start uses RVM in scripts/start_local.sh; Capistrano does not load capistrano-rvm.
 
 set :rails_env, :development
 # Colon-separated groups; required by capistrano-bundler 2.x / Bundler 2.

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -19,6 +19,7 @@ if fetch(:value) != 'Y'
   exit
 end
 set :deploy_to, '/opt/webapps/application_portfolio'
+# rbenv: ensure .ruby-version is installed before bundler:install (see check_ruby.sh).
 after 'deploy:updating', 'ruby_update_check'
 after 'deploy:updating', 'init_qp'
 before 'deploy:cleanup', 'start_qp'

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -15,6 +15,7 @@ ask(:password, nil, echo: false)
 server 'libappstest.libraries.uc.edu', user: fetch(:username), password: fetch(:password),
                                        port: 22, roles: %i[web app db]
 set :deploy_to, '/opt/webapps/application_portfolio'
+# rbenv: ensure .ruby-version is installed before bundler:install (see check_ruby.sh).
 after 'deploy:updating', 'ruby_update_check'
 after 'deploy:updating', 'init_qp'
 before 'deploy:cleanup', 'start_qp'

--- a/scripts/check_ruby.sh
+++ b/scripts/check_ruby.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# Note: Change this to be the version on ruby needed on the server.
-# Could change this to read the .ruby-version in the project
+# QA and production deploy hosts manage Ruby with rbenv (user apache, /home/apache/.rbenv).
+# Runs during cap deploy via ruby_update_check, before bundler:config/install.
+# Installs the version from .ruby-version when missing.
 RUBY_VERSION=$(cat .ruby-version | sed s/ruby-//)
 
 if rbenv versions | grep -q $RUBY_VERSION; then

--- a/scripts/start_local.sh
+++ b/scripts/start_local.sh
@@ -7,4 +7,5 @@ fi
 
 # Kill rails server if exists
 kill -9 $(lsof -i tcp:3000 -t) 2> /dev/null
+# Local cap deploy only: start Rails via RVM. QA/production use rbenv (check_ruby.sh) and systemd.
 source "$HOME/.rvm/scripts/rvm" && bundle exec rails server -p 3000 -b 0.0.0.0 -d


### PR DESCRIPTION
## Summary

Reconciles Ruby version manager usage in Capistrano (LIBAPPO1-96).

**Finding:** QA and production deploy hosts use **rbenv** (`scripts/check_ruby.sh`, user `apache`, `/home/apache/.rbenv`). The `capistrano-rvm` gem was only loaded for the optional `local` stage (`task local: :use_rvm`) and never ran on QA/production deploys.

- Remove **`capistrano-rvm`** gem and Capfile RVM hooks.
- Document Ruby managers in **README** and deploy/script comments.
- Clarify that **local cap deploy** still starts Rails via RVM in `start_local.sh` only; normal local dev is unaffected (developers may use RVM or rbenv locally).

No change to QA/production deploy behavior beyond removing unused RVM integration.

## Test plan

- [ ] `bundle exec cap -T` loads without errors
- [ ] **QA deploy succeeds end-to-end** (`cap qa deploy`)
- [ ] After deploy, app boots and core flows work
- [ ] Confirm `check_ruby.sh` still ensures `.ruby-version` is installed on the server