### PR TITLE
Replace :unprocessable_entity with :unprocessable_content (LIBAPPO1-97)

### DIFF
--- a/app/controllers/shibboleth_sessions_controller.rb
+++ b/app/controllers/shibboleth_sessions_controller.rb
@@ -28,6 +28,6 @@ class ShibbolethSessionsController < ApplicationController
         detail
     end
 
-    render :error, status: :unprocessable_entity
+    render :error, status: :unprocessable_content
   end
 end

--- a/spec/controllers/shibboleth_sessions_controller_spec.rb
+++ b/spec/controllers/shibboleth_sessions_controller_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe ShibbolethSessionsController, type: :controller do
 
         get :create
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response).to render_template(:error)
         expect(response.body).to include('Synthetic validation failure for troubleshooting')
       end
@@ -93,7 +93,7 @@ RSpec.describe ShibbolethSessionsController, type: :controller do
 
         get :create
 
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(response).to render_template(:error)
         expect(response.body).not_to include('Synthetic validation failure for troubleshooting')
         expect(response.body).to include("couldn't finish setting up")


### PR DESCRIPTION
## Summary

Replace `:unprocessable_entity` with `:unprocessable_content` (LIBAPPO1-97). Rack 3 deprecates the old status symbol.

- **`ShibbolethSessionsController`** — error render on failed account provisioning
- **`shibboleth_sessions_controller_spec`** — both error-path expectations updated

No behavior change; HTTP status remains 422.

## Test plan

- [x] `bundle exec rspec spec/controllers/shibboleth_sessions_controller_spec.rb` — 8 examples, 0 failures
- [x] `bundle exec rspec` — full suite passes
- [x] No `:unprocessable_entity` deprecation warning in shibboleth spec output
- [x] `bundle exec rubocop` on changed files — no offenses