### PR TITLE
Audit Rails 8/Rack 3 deprecations and update README (LIBAPPO1-98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,14 @@ This application tracks, monitors, and secures information on all of UCL's servi
 Provided that you have Ruby on Rails installed you can run this application on your local machine or server.
 
 ```bash
-git clone github.com/uclibs/application_profile
+git clone git@github.com:uclibs/application_portfolio.git
+cd application_portfolio
 bundle install
-rails db:migrate
-rails server
+bin/rails db:migrate
+bin/rails server
 ```
+
+Use Ruby **3.4.9** (see `.ruby-version`). Local developers may use **RVM or rbenv**; deploy hosts use rbenv (see Deployment below).
 
 ## Ruby version and System dependencies
 
@@ -20,14 +23,20 @@ Ruby 3.4.9
 Node.js 24.x (see `.nvmrc`; run `nvm install` in the project root)
 
 ## Running the Tests
-The application portfolio has a test suite built with rspec, rubocop, and coveralls, running it is simple, just call the following in the project directory:
+
+The test suite uses RSpec, RuboCop, and Coveralls. From the project root:
+
+```bash
+bundle exec rspec
+bundle exec rubocop
+```
+
+The test environment is configured to **raise on Rails/Rack deprecations** (`config.active_support.deprecation = :raise`), so deprecation warnings fail the suite rather than printing to stderr.
+
+For Coveralls locally:
 
 ```bash
 coveralls report
-```
-
-```bash
-rubocop -a
 ```
 
 ## Database creation
@@ -44,7 +53,7 @@ rails console
 
 email_address = "user@example.com"
 
-user = User.find_by_email(email_address)
+user = User.find_by(email: email_address)
 
 user.roles = "root_admin"
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,8 +47,8 @@ Rails.application.configure do
   # Set host to be used by links generated in mailer templates.
   config.action_mailer.default_url_options = { host: 'example.com' }
 
-  # Print deprecation notices to the stderr.
-  config.active_support.deprecation = :stderr
+  # Fail the suite on deprecations (audit LIBAPPO1-98; :unprocessable_entity fixed in LIBAPPO1-97).
+  config.active_support.deprecation = :raise
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true


### PR DESCRIPTION
## Summary

Audit and resolve remaining Rails 8 / Rack 3 deprecation warnings (LIBAPPO1-98).

**Audit findings:** Full boot (test + development, eager load) and the complete RSpec suite were run with `config.active_support.deprecation = :raise`. The only deprecation in scope was `:unprocessable_entity` → `:unprocessable_content`, already fixed in LIBAPPO1-97 (#431). No other deprecations were found.

**Changes:**
- **`config/environments/test.rb`** — set `deprecation = :raise` so future deprecations fail the suite instead of printing to stderr.
- **`README.md`** — fix clone URL and setup steps; document `bundle exec rspec` / `bundle exec rubocop`; note deprecation policy; update admin console example to `User.find_by(email:)`.

## Deprecations addressed

| Deprecation | Status |
|-------------|--------|
| `:unprocessable_entity` (Rack 3) | Fixed in LIBAPPO1-97 (#431) |
| *(none others found)* | — |

## Test plan

- [x] Boot + eager load (test/dev) with `deprecation = :raise` — no errors
- [x] `bundle exec rspec` — 540 examples, 0 failures
- [x] `bundle exec rubocop` — no offenses
- [x] No deprecation warnings in test output