### PR TITLE
LIBAPPOR1-114 Remove unused asset dependencies and duplicate Bootstrap CDN 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,8 +66,6 @@ gem 'dotenv-rails'
 gem 'petergate'
 # Use gritter for flash message
 gem 'gritter'
-# Use bootstrap-datepicker-rails for datepicker
-gem 'bootstrap-datepicker-rails'
 # Use chartkick for data-visualization techniques
 gem 'chartkick', '~> 5.2'
 # Use groupdate to group by dates

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,8 +89,6 @@ GEM
       msgpack (~> 1.2)
     bootstrap (5.3.8)
       popper_js (>= 2.11.8, < 3)
-    bootstrap-datepicker-rails (1.10.0.1)
-      railties (>= 3.0)
     brakeman (8.0.5)
       racc
     builder (3.3.0)
@@ -457,7 +455,6 @@ DEPENDENCIES
   bigdecimal
   bootsnap (>= 1.1.0)
   bootstrap (~> 5.3.3)
-  bootstrap-datepicker-rails
   brakeman
   bundler-audit
   byebug

--- a/app/assets/javascripts/vendor/bootstrap.bundle.js
+++ b/app/assets/javascripts/vendor/bootstrap.bundle.js
@@ -1,1 +1,0 @@
-../../node_modules/bootstrap/dist/js/bootstrap.bundle.min.js

--- a/app/views/software_records/_form.html.erb
+++ b/app/views/software_records/_form.html.erb
@@ -1,14 +1,3 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Software Record</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.10.2/dist/umd/popper.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
-</head>
-<body>
 <div class="container animated fadeIn" style="opacity: 0.8">
   <div class="card-detail" style="background-color: black; width: 100%;">
     <br />
@@ -16,7 +5,7 @@
       <% if component.eql?("new") %>New Software Record<% else %>Edit Software Record<% end %>
     </h1>
     <p style="font-size: 12px; float: right; margin-right: 30px; margin-bottom: 0px !important; text-align: right;">
-      <b style="color: red; font-size: 20px;">*</b> 
+      <b style="color: red; font-size: 20px;">*</b>
       <span style="color: white;">indicates a required field</span>
     </p>
     <br>
@@ -86,6 +75,3 @@
 <br />
 <br />
 <br />
-</body>
-</html>
-

--- a/app/views/software_records/show.html.erb
+++ b/app/views/software_records/show.html.erb
@@ -1,77 +1,63 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Software Record</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.10.2/dist/umd/popper.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
-</head>
-<body>
-    <div class="container animated fadeIn" style="opacity: 0.9;">
-        <div class="card" style="width: 90%; margin-top: 40px; height: auto; background-color: black; color: white; margin-bottom: 10rem;">
-            <div class="card-header text-center">
-                <h1 style="color: white; font-family: Courier New, Lucida, Console"><%= @software_record.title %></h1>
-                <blockquote class="blockquote text-center">
-                    <div class="blockquote-footer"><cite title="Source Title"><%= @software_record.description %></cite></div>
-                </blockquote>
-                <p class="text-center"><%= pills @software_record.status.title %></p>
-            </div>
-            <div class="card-body" style="padding-top: 1px;">
-                <div class="text-center">
-                    <% if user_signed_in? %>
-                        <% if current_user.role.to_s == "owner" || current_user.role.to_s == "root_admin" || current_user.role.to_s == "manager" %>
-                            <%= link_to 'Edit', edit_software_record_path(@software_record), class: "btn btn-warning nav-links" %>
-                        <% end %>
+<div class="container animated fadeIn" style="opacity: 0.9;">
+    <div class="card" style="width: 90%; margin-top: 40px; height: auto; background-color: black; color: white; margin-bottom: 10rem;">
+        <div class="card-header text-center">
+            <h1 style="color: white; font-family: Courier New, Lucida, Console"><%= @software_record.title %></h1>
+            <blockquote class="blockquote text-center">
+                <div class="blockquote-footer"><cite title="Source Title"><%= @software_record.description %></cite></div>
+            </blockquote>
+            <p class="text-center"><%= pills @software_record.status.title %></p>
+        </div>
+        <div class="card-body" style="padding-top: 1px;">
+            <div class="text-center">
+                <% if user_signed_in? %>
+                    <% if current_user.role.to_s == "owner" || current_user.role.to_s == "root_admin" || current_user.role.to_s == "manager" %>
+                        <%= link_to 'Edit', edit_software_record_path(@software_record), class: "btn btn-warning nav-links" %>
                     <% end %>
-                    <%= link_to 'Back', session[:previous], class: "btn btn-primary nav-links ms-4" %>
+                <% end %>
+                <%= link_to 'Back', session[:previous], class: "btn btn-primary nav-links ms-4" %>
+            </div>
+            <br/>
+
+            <ul class="nav nav-tabs" id="SoftwareRecordsTab" role="tablist">
+                <li class="nav-item">
+                    <a class="nav-link active" id="general-tab" data-bs-toggle="tab" href="#general" role="tab" aria-controls="general"
+                        aria-selected="true">General</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" id="server-environment-tab" data-bs-toggle="tab" href="#server-environment" role="tab" aria-controls="server-environment"
+                        aria-selected="false">Server Environment</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" id="change-management-tab" data-bs-toggle="tab" href="#change-management" role="tab" aria-controls="change-management"
+                        aria-selected="false">Change Management</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" id="upgrade-history-tab" data-bs-toggle="tab" href="#upgrade-history" role="tab" aria-controls="upgrade-history"
+                        aria-selected="false">Upgrade History</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" id="maintenance-log-tab" data-bs-toggle="tab" href="#maintenance-log" role="tab" aria-controls="maintenance-log"
+                        aria-selected="false">Maintenance Log</a>
+                </li>
+            </ul>
+
+            <div class="tab-content" id="SoftwareRecordsTabContent">
+                <div class="tab-pane fade show active" id="general" role="tabpanel" aria-labelledby="general-tab">
+                    <%= render 'general' %>
                 </div>
-                <br/>
-
-                <ul class="nav nav-tabs" id="SoftwareRecordsTab" role="tablist">
-                    <li class="nav-item">
-                        <a class="nav-link active" id="general-tab" data-bs-toggle="tab" href="#general" role="tab" aria-controls="general"
-                            aria-selected="true">General</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" id="server-environment-tab" data-bs-toggle="tab" href="#server-environment" role="tab" aria-controls="server-environment"
-                            aria-selected="false">Server Environment</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" id="change-management-tab" data-bs-toggle="tab" href="#change-management" role="tab" aria-controls="change-management"
-                            aria-selected="false">Change Management</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" id="upgrade-history-tab" data-bs-toggle="tab" href="#upgrade-history" role="tab" aria-controls="upgrade-history"
-                            aria-selected="false">Upgrade History</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" id="maintenance-log-tab" data-bs-toggle="tab" href="#maintenance-log" role="tab" aria-controls="maintenance-log"
-                            aria-selected="false">Maintenance Log</a>
-                    </li>
-                </ul>
-
-                <div class="tab-content" id="SoftwareRecordsTabContent">
-                    <div class="tab-pane fade show active" id="general" role="tabpanel" aria-labelledby="general-tab">
-                        <%= render 'general' %>
-                    </div>
-                    <div class="tab-pane fade" id="server-environment" role="tabpanel" aria-labelledby="server-environment-tab">
-                        <%= render 'server_environment' %>
-                    </div>
-                    <div class="tab-pane fade" id="change-management" role="tabpanel" aria-labelledby="change-management-tab">
-                        <%= render 'change_management' %>
-                    </div>
-                    <div class="tab-pane fade" id="upgrade-history" role="tabpanel" aria-labelledby="upgrade-history-tab">
-                        <%= render 'upgrade_history' %>
-                    </div>
-                    <div class="tab-pane fade" id="maintenance-log" role="tabpanel" aria-labelledby="maintenance-log-tab">
-                        <%= render 'maintenance_log' %>
-                    </div>
+                <div class="tab-pane fade" id="server-environment" role="tabpanel" aria-labelledby="server-environment-tab">
+                    <%= render 'server_environment' %>
+                </div>
+                <div class="tab-pane fade" id="change-management" role="tabpanel" aria-labelledby="change-management-tab">
+                    <%= render 'change_management' %>
+                </div>
+                <div class="tab-pane fade" id="upgrade-history" role="tabpanel" aria-labelledby="upgrade-history-tab">
+                    <%= render 'upgrade_history' %>
+                </div>
+                <div class="tab-pane fade" id="maintenance-log" role="tabpanel" aria-labelledby="maintenance-log-tab">
+                    <%= render 'maintenance_log' %>
                 </div>
             </div>
         </div>
     </div>
-</body>
-</html>
-
+</div>


### PR DESCRIPTION
## Summary

- Remove unused `bootstrap-datepicker-rails` gem (not referenced in views or JS).
- Remove duplicate Bootstrap 5.1.3 CDN `<link>` / `<script>` tags from `software_records/show.html.erb` and `_form.html.erb`; Bootstrap is already loaded via the `software_records` layout and asset pipeline.
- Strip nested `<!DOCTYPE>` / `<html>` / `<body>` wrappers from those views so they render correctly inside the layout.
- Delete unused `app/assets/javascripts/vendor/bootstrap.bundle.js` stub (app uses `//= require bootstrap` from the gem).

Part of asset pipeline modernization (**LIBAPPO1-114**, ticket #8); gates dartsass and jsbundling work.

## Test plan

- [x] `bundle exec rubocop`
- [x] `bundle exec rspec` (540 examples, 0 failures, 5 pending)
- [x] `bundle exec rails assets:precompile`
- [x] Grep: no remaining `bootstrap-datepicker`, Bootstrap CDN, or `vendor/bootstrap` references
- [ ] Manual smoke test on QA: software record show/edit tabs and styling