### PR TITLE
LIBAPPO1-102 Replace sassc-rails with dartsass-rails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ yarn.lock
 # Ignore .env.production and .env.production.local
 .env.production
 .env.production.local
+
+/app/assets/builds/*
+!/app/assets/builds/.keep

--- a/Gemfile
+++ b/Gemfile
@@ -31,10 +31,11 @@ gem 'rack', '~> 3.0'
 
 # Use Puma as the app server
 gem 'puma', '>= 6.4.3'
-# Use SCSS for stylesheets
-gem 'sass-rails', '~> 6.0'
+# Compile SCSS with Dart Sass (replaces deprecated sassc-rails / LibSass)
+gem 'dartsass-rails'
 # Asset pipeline dependencies for Rack 3.x compatibility
 gem 'sprockets', '~> 4.2', '>= 4.2.2'
+gem 'sprockets-rails'
 # Use Devise for authentication
 gem 'devise'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
@@ -59,7 +60,6 @@ gem 'simplecov-lcov', require: false
 # Use bootstrap css, jquery-rails gem for styling the components
 gem 'bootstrap', '~> 5.3.3'
 gem 'jquery-rails'
-gem 'sassc-rails', '~> 2.1' # SASSC adapter for Rails, needed for Bootstrap 5
 # Use dotenv gem to store the environment variables
 gem 'dotenv-rails'
 # Use petergate for authorization
@@ -104,6 +104,7 @@ group :development do
   # 2.x uses `bundler:config` (bundle config --local) before install; see config/deploy.rb.
   gem 'capistrano-bundler', '~> 2.2', require: false
   gem 'capistrano-rails', '~> 1.4', require: false
+  gem 'foreman'
   # Access an interactive console on exception pages or by calling 'console' anywhere in the code.
   gem 'listen', '~> 3.5'
   gem 'web-console', '>= 3.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,6 +121,9 @@ GEM
     connection_pool (3.0.2)
     crass (1.0.6)
     csv (3.3.5)
+    dartsass-rails (0.5.1)
+      railties (>= 6.0.0)
+      sass-embedded (~> 1.63)
     database_cleaner-active_record (2.2.2)
       activerecord (>= 5.a)
       database_cleaner-core (~> 2.0)
@@ -154,6 +157,8 @@ GEM
     ffi (1.17.4-x86-linux-gnu)
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
+    foreman (0.90.0)
+      thor (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
     globalize (7.1.3)
@@ -161,6 +166,24 @@ GEM
       activerecord (>= 7.0, < 8.2)
       activesupport (>= 7.0, < 8.2)
       request_store (~> 1.0)
+    google-protobuf (4.35.1)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-arm64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86_64-darwin)
+      bigdecimal
+      rake (~> 13.3)
+    google-protobuf (4.35.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (~> 13.3)
     gritter (1.2.0)
     groupdate (6.8.0)
       activesupport (>= 7.2)
@@ -362,16 +385,19 @@ GEM
       rubocop (~> 1.86, >= 1.86.2)
     ruby-progressbar (1.13.0)
     rubyzip (3.4.0)
-    sass-rails (6.0.0)
-      sassc-rails (~> 2.1, >= 2.1.1)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
+    sass-embedded (1.101.0)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.101.0-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.101.0-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
     securerandom (0.4.1)
     selenium-webdriver (4.45.0)
       base64 (~> 0.2)
@@ -413,7 +439,6 @@ GEM
       ostruct
     stringio (3.2.0)
     thor (1.5.0)
-    tilt (2.7.0)
     timeout (0.6.1)
     tsort (0.2.0)
     turbolinks (5.2.1)
@@ -464,12 +489,14 @@ DEPENDENCIES
   capybara (>= 2.15)
   chartkick (~> 5.2)
   csv
+  dartsass-rails
   database_cleaner-active_record
   devise
   dotenv-rails
   drb
   ed25519
   factory_bot_rails
+  foreman
   globalize (~> 7.0)
   gritter
   groupdate
@@ -497,13 +524,12 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   rubocop-rspec
-  sass-rails (~> 6.0)
-  sassc-rails (~> 2.1)
   selenium-webdriver (>= 4.18.1)
   shoulda-matchers (~> 7.0)
   simplecov
   simplecov-lcov
   sprockets (~> 4.2, >= 4.2.2)
+  sprockets-rails
   sqlite3 (>= 2.1)
   turbolinks (~> 5)
   tzinfo-data

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server -p 3000
+css: bin/rails dartsass:watch

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,3 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
-//= link_directory ../stylesheets .css
+//= link_tree ../builds

--- a/app/assets/stylesheets/_gem_dependencies.scss
+++ b/app/assets/stylesheets/_gem_dependencies.scss
@@ -1,0 +1,10 @@
+// Shared Bootstrap + gritter imports for dartsass entry points.
+//
+// The gritter gem names its stylesheet gritter.css.scss — use that exact import
+// path so Dart Sass inlines it at compile time. @import "gritter.css" emits a
+// runtime CSS @import that Sprockets cannot resolve (the browser loads Rails
+// HTML as CSS and layout breaks).
+$enable-responsive-font-sizes: false;
+
+@import "gritter.css.scss";
+@import "bootstrap";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,8 +1,6 @@
-$enable-responsive-font-sizes: false;
-
-@import "bootstrap";
-@import "gritter";
-@import "**/*";
+@import "gem_dependencies";
+@import "vendor_records";
+@import "software_types";
 
 html,
 body {

--- a/app/assets/stylesheets/change_request.scss
+++ b/app/assets/stylesheets/change_request.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the ChangeRequest controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/change_requests.scss
+++ b/app/assets/stylesheets/change_requests.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the ChangeRequests controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/software_records.scss
+++ b/app/assets/stylesheets/software_records.scss
@@ -1,7 +1,4 @@
-$enable-responsive-font-sizes: false;
-
-@import "bootstrap";
-@import "gritter";
+@import "gem_dependencies";
 
 html,
 body {

--- a/app/assets/stylesheets/software_types.scss
+++ b/app/assets/stylesheets/software_types.scss
@@ -1,8 +1,3 @@
-$enable-responsive-font-sizes: false;
-
-@import "bootstrap";
-@import "gritter";
-
 html,
 body {
   height: 100%;

--- a/app/assets/stylesheets/statuses.scss
+++ b/app/assets/stylesheets/statuses.scss
@@ -1,3 +1,0 @@
-// Place all the styles related to the Statuses controller here.
-// They will automatically be included in application.css.
-// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/vendor_records.scss
+++ b/app/assets/stylesheets/vendor_records.scss
@@ -1,8 +1,3 @@
-
-
-@import "bootstrap";
-@import "gritter";
-
 html,
 body {
   height: 100%;

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+exec bundle exec foreman start -f Procfile.dev "$@"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,8 +33,7 @@ Rails.application.configure do
   # Cache assets for far-future expiry since they are all digest stamped.
   config.public_file_server.headers = { 'cache-control' => "public, max-age=#{1.year.to_i}" }
 
-  # Compress CSS. Precompile list is in config/initializers/assets.rb.
-  config.assets.css_compressor = :sass
+  # CSS is compressed by dartsass-rails (--style=compressed). Precompile list is in config/initializers/assets.rb.
   config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -7,8 +7,9 @@ Rails.application.config.assets.version = '1.0'
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
-# Add Yarn node_modules folder to the asset load path.
+# Add Yarn node_modules folder to the asset load path (used by future jsbundling; see LIBAPPO1-#17).
 Rails.application.config.assets.paths << Rails.root.join('node_modules')
+# Compiled CSS from dartsass-rails lives in app/assets/builds/ (linked in manifest.js).
 Rails.application.config.assets.precompile += %w[software_records.css]
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Entry-point SCSS files compiled to app/assets/builds/ by dartsass-rails.
+# Bootstrap and gritter still come from gems until npm migration (LIBAPPO1-#16).
+# Gritter import rules live in app/assets/stylesheets/_gem_dependencies.scss.
+gritter_stylesheets = File.join(Gem.loaded_specs['gritter'].full_gem_path, 'app/assets/stylesheets')
+bootstrap_stylesheets = File.join(Gem.loaded_specs['bootstrap'].full_gem_path, 'assets/stylesheets')
+
+Rails.application.config.dartsass.build_options ||= []
+Rails.application.config.dartsass.build_options << "--load-path=#{gritter_stylesheets}"
+Rails.application.config.dartsass.build_options << "--load-path=#{bootstrap_stylesheets}"
+
+Rails.application.config.dartsass.builds = {
+  'application.scss' => 'application.css',
+  'software_records.scss' => 'software_records.css'
+}

--- a/spec/support/dartsass.rb
+++ b/spec/support/dartsass.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Tests need freshly compiled CSS from app/assets/builds/. A leftover
+# public/assets manifest from assets:precompile pins stale digests and can
+# make stylesheet_link_tag serve outdated CSS (e.g. a runtime gritter @import
+# that resolves to Rails HTML).
+RSpec.configure do |config|
+  config.before(:suite) do
+    public_assets = Rails.public_path.join('assets')
+    FileUtils.rm_rf(public_assets) if public_assets.directory?
+
+    Rails.application.load_tasks
+    Rake::Task['dartsass:build'].reenable
+    Rake::Task['dartsass:build'].invoke
+  end
+end


### PR DESCRIPTION
## Summary

Replaces deprecated `sass-rails` / `sassc-rails` (LibSass) with `dartsass-rails` and compiles SCSS entry points to `app/assets/builds/` while Sprockets continues to serve assets (Propshaft deferred to #19).

- Remove `sass-rails` and `sassc-rails`; add `dartsass-rails`, explicit `sprockets-rails`, and `foreman` (dev) for `bin/dev`
- Configure dartsass to build `application.scss` → `application.css` and `software_records.scss` → `software_records.css`
- Point Sprockets manifest at `app/assets/builds/` instead of compiling stylesheets via LibSass
- Add `_gem_dependencies.scss` for shared Bootstrap/gritter imports (inlined at compile time; gritter must use `gritter.css.scss` to avoid a broken runtime CSS `@import`)
- Replace sass-rails `**/*` glob with explicit imports in `application.scss`
- Remove production `config.assets.css_compressor = :sass` (dartsass already compresses output)
- Add `spec/support/dartsass.rb` to clear stale `public/assets` manifests and run `dartsass:build` before the suite
- Delete empty SCSS boilerplate (`change_request`, `change_requests`, `statuses`)
- `application.css` size reduced ~704KB → ~240KB by deduplicating Bootstrap/gritter across partial imports

Bootstrap still comes from the gem temporarily (#16). Layouts unchanged (`stylesheet_link_tag 'application'` / `'software_records'`).

## Test plan

- [x] `bin/rails dartsass:build` — produces `application.css` and `software_records.css` in `app/assets/builds/`
- [x] `bundle exec rails assets:precompile`
- [x] `bundle exec rubocop`
- [x] `bundle exec rspec` — 540 examples, 0 failures
- [ ] Visual spot-check: dashboard, software record form, change request pages
- [ ] QA deploy: confirm `assets:precompile` on server after merge

## Dependencies

- Depends on: #8 (asset dep cleanup) — merged on `qa`
- Blocks: #16 (npm Bootstrap), #19 (Propshaft)

## Follow-up

- Consolidate duplicated dashboard layout SCSS (`.sidenav`, `#main`, etc.) across `application.scss`, `software_records.scss`, `vendor_records.scss`, and `software_types.scss` — separate ticket