### PR TITLE
Use native date inputs instead of bootstrap-datepicker (LIBAPPO1-105).

### DIFF
--- a/app/assets/stylesheets/_dashboard_base.scss
+++ b/app/assets/stylesheets/_dashboard_base.scss
@@ -24,6 +24,11 @@ a:hover {
   color: black;
 }
 
+// Native date picker on dark dashboard forms: use a light calendar UI.
+input[type="date"].form-control {
+  color-scheme: light;
+}
+
 option {
   padding: 0 24px;
 }

--- a/app/views/change_requests/_form.html.erb
+++ b/app/views/change_requests/_form.html.erb
@@ -44,7 +44,7 @@
 
         <div class="field">
           <%= form.label :change_submitted_date %>
-          <%= form.date_field :change_submitted_date, :class => "form-control" %>
+          <%= form.date_field :change_submitted_date, class: "form-control" %>
         </div><br/>
 
         <div class="field">

--- a/app/views/front/new.html.erb
+++ b/app/views/front/new.html.erb
@@ -24,14 +24,14 @@
           <% if user_signed_in? && current_user.role.to_s == "owner" %>
             <div class="mb-3">
               <%= form.label :date_implemented %>
-              <%= form.date_field :date_implemented, as: :date, value: form.object.try(:strftime,"%m/%d/%Y"), class: 'form-control' %>
+              <%= form.date_field :date_implemented, class: "form-control" %>
             </div>
           <% end %>
 
           <% if user_signed_in? && current_user.role.to_s == "owner" %>
             <div class="mb-3">
               <%= form.label :date_of_upgrade %>
-              <%= form.date_field :date_of_upgrade, as: :date, value: form.object.try(:strftime,"%m/%d/%Y"), class: 'form-control' %>
+              <%= form.date_field :date_of_upgrade, class: "form-control" %>
             </div>
           <% end %>
 

--- a/app/views/software_records/_form_change_management.html.erb
+++ b/app/views/software_records/_form_change_management.html.erb
@@ -14,22 +14,22 @@
 
 <div class="mb-3">
   <%= form.label :last_security_scan, "Last Security Scan", for: "software_record_last_security_scan" %>
-  <%= form.date_field :last_security_scan, as: :date, value: form.object.try(:strftime, "%m/%d/%Y"), class: "form-control", id: "software_record_last_security_scan" %>
+  <%= form.date_field :last_security_scan, class: "form-control", id: "software_record_last_security_scan" %>
 </div>
 
 <div class="mb-3">
   <%= form.label :last_accessibility_scan, "Last Accessibility Scan", for: "software_record_last_accessibility_scan" %>
-  <%= form.date_field :last_accessibility_scan, as: :date, value: form.object.try(:strftime, "%m/%d/%Y"), class: "form-control", id: "software_record_last_accessibility_scan" %>
+  <%= form.date_field :last_accessibility_scan, class: "form-control", id: "software_record_last_accessibility_scan" %>
 </div>
 
 <div class="mb-3">
   <%= form.label :last_ogc_review, "Last OGC Review", for: "software_record_last_ogc_review" %>
-  <%= form.date_field :last_ogc_review, as: :date, value: form.object.try(:strftime, "%m/%d/%Y"), class: "form-control", id: "software_record_last_ogc_review" %>
+  <%= form.date_field :last_ogc_review, class: "form-control", id: "software_record_last_ogc_review" %>
 </div>
 
 <div class="mb-3">
   <%= form.label :last_info_sec_review, "Last InfoSec Review", for: "software_record_last_info_sec_review" %>
-  <%= form.date_field :last_info_sec_review, as: :date, value: form.object.try(:strftime, "%m/%d/%Y"), class: "form-control", id: "software_record_last_info_sec_review" %>
+  <%= form.date_field :last_info_sec_review, class: "form-control", id: "software_record_last_info_sec_review" %>
 </div>
 
 <div class="mb-3">

--- a/app/views/software_records/_form_general.html.erb
+++ b/app/views/software_records/_form_general.html.erb
@@ -15,12 +15,12 @@
 
 <div class="mb-3">
   <%= form.label :date_implemented, "Date Implemented", for: "software_record_date_implemented" %>
-  <%= form.date_field :date_implemented, as: :date, value: form.object.try(:strftime, "%m/%d/%Y"), class: 'form-control', id: "software_record_date_implemented" %>
+  <%= form.date_field :date_implemented, class: "form-control", id: "software_record_date_implemented" %>
 </div>
 
 <div class="mb-3">
   <%= form.label :date_of_upgrade, "Date of Last Upgrade", for: "software_record_date_of_upgrade" %>
-  <%= form.date_field :date_of_upgrade, as: :date, value: form.object.try(:strftime, "%m/%d/%Y"), class: 'form-control', id: "software_record_date_of_upgrade" %>
+  <%= form.date_field :date_of_upgrade, class: "form-control", id: "software_record_date_of_upgrade" %>
 </div>
 
 <div class="mb-3">

--- a/app/views/software_records/_form_maintenance_log.html.erb
+++ b/app/views/software_records/_form_maintenance_log.html.erb
@@ -1,8 +1,4 @@
-<!-- app/views/software_records/edit.html.erb -->
-
-<h1>Edit Software Record</h1>
-
-  <div class="mb-3">
+<div class="mb-3">
     <%= form.label :service %>
     <%= form.text_field :service, :class => "form-control" %>
   </div>
@@ -18,8 +14,8 @@
   </div>
 
   <div class="mb-3">
-    <%= form.label :last_upgrade_date %>
-    <%= form.date_field :last_upgrade_date, as: :date, value: form.object.try(:strftime,"%m/%d/%Y"), :class => "form-control" %>
+    <%= form.label :last_upgrade_date, for: "software_record_last_upgrade_date" %>
+    <%= form.date_field :last_upgrade_date, class: "form-control", id: "software_record_last_upgrade_date" %>
   </div>
 
   <div class="mb-3">

--- a/app/views/software_records/_form_server_environment.html.erb
+++ b/app/views/software_records/_form_server_environment.html.erb
@@ -40,12 +40,12 @@
 
 <div class="mb-3">
   <%= form.label :last_record_change, "Last Record Change", for: "software_record_last_record_change" %>
-  <%= form.date_field :last_record_change, as: :date, value: form.object.try(:strftime, "%m/%d/%Y"), class: "form-control", id: "software_record_last_record_change" %>
+  <%= form.date_field :last_record_change, class: "form-control", id: "software_record_last_record_change" %>
 </div>
 
 <div class="mb-3">
   <%= form.label :date_cert_expires, "Certificate Expiration", for: "software_record_date_cert_expires" %>
-  <%= form.date_field :date_cert_expires, as: :date, value: form.object.try(:strftime, "%m/%d/%Y"), class: "form-control", id: "software_record_date_cert_expires" %>
+  <%= form.date_field :date_cert_expires, class: "form-control", id: "software_record_date_cert_expires" %>
 </div>
 
 <fieldset class="mb-3">

--- a/spec/views/change_requests/new_html.erb_spec.rb
+++ b/spec/views/change_requests/new_html.erb_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'change_requests/new.html.erb', type: :view do
     assert_select 'form[action=?][method=?]', change_requests_path, 'post' do
       assert_select 'input[name=?]', 'change_request[change_title]'
       assert_select 'textarea[name=?]', 'change_request[change_description]'
-      assert_select 'input[name=?]', 'change_request[change_submitted_date]'
+      assert_select 'input[name=?][type=?]', 'change_request[change_submitted_date]', 'date'
       assert_select 'input[type=?]', 'checkbox', count: 3
       assert_select 'input[name=?]', 'change_request[application_pages]'
       assert_select 'input[name=?]', 'change_request[number_roles]'

--- a/spec/views/software_records/edit.html.erb_spec.rb
+++ b/spec/views/software_records/edit.html.erb_spec.rb
@@ -67,6 +67,14 @@ RSpec.describe 'software_records/edit', type: :view do
     end
   end
 
+  it 'renders native date inputs with ISO values' do
+    @software_record.update!(date_implemented: Date.new(2020, 12, 12), last_security_scan: Date.new(2021, 6, 15))
+    render
+
+    assert_select 'input#software_record_date_implemented[type=date][value=?]', '2020-12-12'
+    assert_select 'input#software_record_last_security_scan[type=date][value=?]', '2021-06-15'
+  end
+
   it 'renders form tab links' do
     render
 
@@ -114,6 +122,7 @@ RSpec.describe 'software_records/edit', type: :view do
       assert_select 'input[name=?]', 'software_record[service]'
       assert_select 'textarea[name=?]', 'software_record[installed_version]'
       assert_select 'textarea[name=?]', 'software_record[proposed_version]'
+      assert_select 'input[name=?][type=?]', 'software_record[last_upgrade_date]', 'date'
       assert_select 'input[name=?]', 'software_record[monitor_errors]'
       assert_select 'select[name=?]', 'software_record[priority]' do
         assert_select 'option[value=?]', '', text: ''


### PR DESCRIPTION
## Summary

Completes **LIBAPPO1-105** by finishing the migration from bootstrap-datepicker to native HTML5 date inputs (`input[type=date]`). The gem was already removed in #434; this PR fixes the remaining view and styling fallout.

- Remove invalid `as: :date` and broken `value: form.object.try(:strftime, ...)` options from all `date_field` helpers — those called `strftime` on the record object instead of the date attribute, so edit forms never showed saved dates
- Standardize date fields across software record partials, change requests, and front/new to plain `form.date_field` (Rails emits ISO `YYYY-MM-DD` values automatically)
- Add `color-scheme: light` on `input[type="date"].form-control` so native calendar UI is readable on dark dashboard forms
- Clean up `_form_maintenance_log` partial: remove stray edit-page heading/comment and add explicit `id`/`for` on `last_upgrade_date`
- Extend view specs to assert `type="date"` and ISO values on edit

## Test plan

- [ ] `bundle exec rubocop` passes
- [ ] `bundle exec rspec` passes (541 examples)
- [ ] Edit a software record with existing dates (General, Change Management, Server Environment, Maintenance Log tabs) — saved dates appear in date inputs
- [ ] Create/edit a change request — submitted date uses native date picker
- [ ] Owner flow on front/new — date implemented and date of upgrade fields work
- [ ] On QA/staging dark forms, open a native date picker and confirm calendar UI is legible