### PR TITLE
Libappo1 106 migrate turbolinks → turbo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,8 +38,8 @@ gem 'sprockets', '~> 4.2', '>= 4.2.2'
 gem 'sprockets-rails'
 # Use Devise for authentication
 gem 'devise'
-# Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# Hotwire Turbo for fast in-app navigation (replaces turbolinks)
+gem 'turbo-rails', '~> 2.0'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use rails-controller-testing for testing a controller

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -441,9 +441,9 @@ GEM
     thor (1.5.0)
     timeout (0.6.1)
     tsort (0.2.0)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
+    turbo-rails (2.0.23)
+      actionpack (>= 7.1.0)
+      railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.2.0)
@@ -531,7 +531,7 @@ DEPENDENCIES
   sprockets (~> 4.2, >= 4.2.2)
   sprockets-rails
   sqlite3 (>= 2.1)
-  turbolinks (~> 5)
+  turbo-rails (~> 2.0)
   tzinfo-data
   web-console (>= 3.3.0)
 

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,7 +15,6 @@
 //= require bootstrap
 //= require gritter
 //= require activestorage
-//= require turbolinks
 //= require chartkick
 //= require Chart.bundle
 //= require_tree .

--- a/app/assets/javascripts/inputsanitization.js
+++ b/app/assets/javascripts/inputsanitization.js
@@ -1,9 +1,8 @@
-document.addEventListener("DOMContentLoaded", function () {
+document.addEventListener("turbo:load", function () {
   var createdbyfield = document.getElementsByClassName('regex-createdby')[0];
   if (createdbyfield) {
     createdbyfield.onkeyup = function() {
-      createdbyfield.value = createdbyfield.value.replace(/[^a-zA-Z0-9 ]/g, ''); // fixed regex too
+      createdbyfield.value = createdbyfield.value.replace(/[^a-zA-Z0-9 ]/g, '');
     };
   }
 });
-

--- a/app/assets/javascripts/show_tab.js
+++ b/app/assets/javascripts/show_tab.js
@@ -1,4 +1,4 @@
-document.addEventListener("turbolinks:load", function () {
+document.addEventListener("turbo:load", function () {
   const hash = window.location.hash;
   if (hash) {
     const tabTrigger = document.querySelector(`a[href="${hash}"]`);

--- a/app/assets/javascripts/show_tab.js
+++ b/app/assets/javascripts/show_tab.js
@@ -1,10 +1,13 @@
 document.addEventListener("turbo:load", function () {
   const hash = window.location.hash;
-  if (hash) {
-    const tabTrigger = document.querySelector(`a[href="${hash}"]`);
-    if (tabTrigger) {
-      const tab = new bootstrap.Tab(tabTrigger);
-      tab.show();
-    }
+  if (!hash) return;
+
+  const tabList = document.querySelector("#softwareRecordTab, #SoftwareRecordsTab");
+  if (!tabList) return;
+
+  const tabTrigger = tabList.querySelector(`a[href="${hash}"]`);
+  if (tabTrigger) {
+    const tab = new bootstrap.Tab(tabTrigger);
+    tab.show();
   }
 });

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,8 +9,9 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.12.0/css/all.css" integrity="sha384-REHJTs1r2ErKBuJB0fCK99gCYsVjwxHrSU0N7I1zl9vZbggVJXRMsv/sLlOAGb4M" 
 crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.2/animate.min.css">
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbo-track': 'reload' %>
+    <%= javascript_include_tag 'turbo', type: 'module', 'data-turbo-track': 'reload' %>
+    <%= javascript_include_tag 'application', 'data-turbo-track': 'reload' %>
   </head>
   <body>
     <%= render 'shared/dashboard_menu' %>

--- a/app/views/layouts/software_records.html.erb
+++ b/app/views/layouts/software_records.html.erb
@@ -9,8 +9,9 @@
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.12.0/css/all.css" integrity="sha384-REHJTs1r2ErKBuJB0fCK99gCYsVjwxHrSU0N7I1zl9vZbggVJXRMsv/sLlOAGb4M" 
 crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/3.7.2/animate.min.css">
-    <%= stylesheet_link_tag 'software_records', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag 'software_records', media: 'all', 'data-turbo-track': 'reload' %>
+    <%= javascript_include_tag 'turbo', type: 'module', 'data-turbo-track': 'reload' %>
+    <%= javascript_include_tag 'application', 'data-turbo-track': 'reload' %>
   </head>
   <body>
     <%= render 'shared/dashboard_menu' %>

--- a/app/views/software_records/list_upgrades.html.erb
+++ b/app/views/software_records/list_upgrades.html.erb
@@ -143,12 +143,10 @@ onclick="clearFiltersAndRedirect('list_upgrades')">Clear all filters <i class="f
           <td style="background-color: black; color: white"><%= link_to 'View', software_record, class: "btn btn-success" %></td>
         <% elsif current_user.role.to_s == "owner" %>
           <td style="background-color: black; color: white"><%= link_to 'View', software_record, class: "btn btn-success" %></td>
-          <td style="background-color: black ; color: white"><%= link_to 'Edit', "#{edit_software_record_path(software_record)}#maintenance-log", class: "btn btn-primary", data: { turbo: false } 
-%></td>
+          <td style="background-color: black ; color: white"><%= link_to 'Edit', "#{edit_software_record_path(software_record)}#maintenance-log", class: "btn btn-primary" %></td>
         <% else %>
           <td style="background-color: black; color: white"><%= link_to 'View', software_record, class: "btn btn-success" %></td>
-          <td style="background-color: black ; color: white"><%= link_to 'Edit', "#{edit_software_record_path(software_record)}#maintenance-log", class: "btn btn-primary", data: { turbo: false } 
-%></td>
+          <td style="background-color: black ; color: white"><%= link_to 'Edit', "#{edit_software_record_path(software_record)}#maintenance-log", class: "btn btn-primary" %></td>
           <td style="background-color: black; color: white"><%= link_to 'Delete', software_record, method: :delete, class: "btn btn-danger", data: { confirm: 'Are you sure?' } %></td>
 
         <% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -285,12 +285,9 @@ Devise.setup do |config|
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
 
-  # ==> Turbolinks configuration
-  # If your app is using Turbolinks, Turbolinks::Controller needs to be included to make redirection work correctly:
-  #
-  # ActiveSupport.on_load(:devise_failure_app) do
-  #   include Turbolinks::Controller
-  # end
+  # ==> Turbo configuration
+  # Turbo Drive is enabled via turbo-rails. Devise works with Turbo out of the box;
+  # the legacy Turbolinks::Controller include is not required.
 
   # ==> Configuration for :registerable
 

--- a/spec/features/software_records/tab_navigation_spec.rb
+++ b/spec/features/software_records/tab_navigation_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.feature 'Software record tab navigation', type: :feature, js: true do
+  let(:user) { FactoryBot.create(:admin) }
+  let(:software_record) { FactoryBot.create(:software_record, priority: 10) }
+
+  before do
+    login_as(user, scope: :user)
+  end
+
+  scenario 'opens the maintenance log tab when the edit URL includes a hash' do
+    visit "#{edit_software_record_path(software_record)}#maintenance-log"
+
+    expect(page).to have_css('#maintenance-log-tab.nav-link.active')
+    expect(page).to have_css('#maintenance-log.tab-pane.active', visible: :all)
+    expect(page).to have_no_css('#general-tab.nav-link.active')
+    expect(page).to have_no_css('#general.tab-pane.active', visible: :all)
+  end
+
+  scenario 'opens the change management tab when the show URL includes a hash' do
+    visit "#{software_record_path(software_record)}#change-management"
+
+    expect(page).to have_css('#change-management-tab.nav-link.active')
+    expect(page).to have_css('#change-management.tab-pane.active', visible: :all)
+  end
+
+  scenario 'activates the hash tab after Turbo navigation from another page' do
+    maintenance_log_url = "#{edit_software_record_path(software_record)}#maintenance-log"
+
+    visit software_records_path
+    page.execute_script("Turbo.visit('#{maintenance_log_url}')")
+
+    expect(page).to have_css('#maintenance-log-tab.nav-link.active', wait: 5)
+    expect(page.evaluate_script('window.location.hash')).to eq('#maintenance-log')
+  end
+end

--- a/spec/requests/turbo_layout_spec.rb
+++ b/spec/requests/turbo_layout_spec.rb
@@ -12,9 +12,16 @@ RSpec.describe 'Turbo layout integration', type: :request do
 
     expect(response).to have_http_status(:ok)
     expect(response.body).to include('data-turbo-track="reload"')
-    expect(response.body).to include('turbo')
-    expect(response.body).to include('type="module"')
+    expect(response.body).to match(%r{<script[^>]+src="[^"]*/turbo[^"]*"[^>]+type="module"})
     expect(response.body).not_to include('data-turbolinks-track')
+    expect(response.body).not_to include('turbolinks')
+
+    script_sources = response.body.scan(/<script[^>]+src="([^"]+)"/).flatten
+    turbo_position = script_sources.index { |src| src.include?('/turbo') }
+    application_position = script_sources.index { |src| src.include?('/application') }
+    expect(turbo_position).to be_present
+    expect(application_position).to be_present
+    expect(turbo_position).to be < application_position
   end
 
   it 'renders software_records layout with data-turbo-track assets' do
@@ -22,6 +29,7 @@ RSpec.describe 'Turbo layout integration', type: :request do
 
     expect(response).to have_http_status(:ok)
     expect(response.body).to include('data-turbo-track="reload"')
+    expect(response.body).to include('type="module"')
     expect(response.body).not_to include('data-turbolinks-track')
   end
 end

--- a/spec/requests/turbo_layout_spec.rb
+++ b/spec/requests/turbo_layout_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Turbo layout integration', type: :request do
+  before do
+    sign_in FactoryBot.create(:admin)
+  end
+
+  it 'renders application layout with data-turbo-track assets' do
+    get root_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('data-turbo-track="reload"')
+    expect(response.body).to include('turbo')
+    expect(response.body).to include('type="module"')
+    expect(response.body).not_to include('data-turbolinks-track')
+  end
+
+  it 'renders software_records layout with data-turbo-track assets' do
+    get software_records_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('data-turbo-track="reload"')
+    expect(response.body).not_to include('data-turbolinks-track')
+  end
+end

--- a/spec/views/software_records/list_upgrades.html.erb_spec.rb
+++ b/spec/views/software_records/list_upgrades.html.erb_spec.rb
@@ -91,7 +91,8 @@ RSpec.describe 'software_records/list_upgrades', type: :view do
   it 'links to edit maintenance log tab without disabling Turbo' do
     render
 
-    edit_href = "#{edit_software_record_path(assign(:software_records).first)}#maintenance-log"
+    software_record = SoftwareRecord.find_by!(title: 'Title')
+    edit_href = "#{edit_software_record_path(software_record)}#maintenance-log"
     assert_select 'a[href=?]', edit_href
     assert_select 'a[data-turbo="false"]', count: 0
   end

--- a/spec/views/software_records/list_upgrades.html.erb_spec.rb
+++ b/spec/views/software_records/list_upgrades.html.erb_spec.rb
@@ -88,6 +88,14 @@ RSpec.describe 'software_records/list_upgrades', type: :view do
     expect(rendered).to have_content('Title 3')
   end
 
+  it 'links to edit maintenance log tab without disabling Turbo' do
+    render
+
+    edit_href = "#{edit_software_record_path(assign(:software_records).first)}#maintenance-log"
+    assert_select 'a[href=?]', edit_href
+    assert_select 'a[data-turbo="false"]', count: 0
+  end
+
   it 'does not display the software record without priority' do
     render
     expect(rendered).not_to have_content('Title 2')


### PR DESCRIPTION
## Summary

Migrates **LIBAPPO1-106** from unmaintained Turbolinks to **turbo-rails** (Hotwire Turbo Drive).

- Replace `turbolinks` gem with `turbo-rails ~> 2.0`
- Load Turbo as an **ES module** in both layouts (`javascript_include_tag 'turbo', type: 'module'`) — do **not** Sprockets-require it into `application.js` (the bundled `turbo.js` uses `export`, which breaks the entire JS bundle with `Uncaught SyntaxError: Unexpected token 'export'`)
- Update asset tracking: `data-turbolinks-track` → `data-turbo-track` in `application.html.erb` and `software_records.html.erb`
- Update `show_tab.js`: `turbolinks:load` → `turbo:load`; scope hash tab lookup to `#softwareRecordTab` / `#SoftwareRecordsTab`
- Update `inputsanitization.js`: `DOMContentLoaded` → `turbo:load` so created-by field sanitization works after in-app navigation
- Remove obsolete Devise Turbolinks comment; note Turbo works without `Turbolinks::Controller`
- Remove `data: { turbo: false }` from `list_upgrades` edit links — hash tab selection works with Turbo + `show_tab.js`
- Add request/feature/view specs for layout integration, hash-based tab navigation, and Turbo-enabled edit links

## Test plan

- [ ] `bundle exec rubocop` passes
- [ ] `bundle exec rspec` passes (547 examples)
- [ ] **Layout / assets:** View page source — Turbo script is `type="module"` and loads before `application.js`; no `data-turbolinks-track` or `turbolinks` references
- [ ] **In-app navigation:** Click between dashboard, software records index, edit, and show — no console errors
- [ ] **Hash tabs:** From list upgrades, click Edit → lands on maintenance log tab; direct visit to edit/show URL with `#maintenance-log` or `#change-management` opens correct tab
- [ ] **Multi-value fields:** On software record edit, add/remove developers (or other multi-value sections) — still works after Turbo navigation
- [ ] **Forms:** Create/edit a software record and change request — submit succeeds, flash/gritter messages appear
- [ ] **Delete:** Delete link with confirm dialog works from an index page
- [ ] **Devise:** Sign in, sign out, failed login — redirects behave correctly
- [ ] **Dashboard charts:** Navigate to dashboard via menu (not full refresh) — pie/line charts render
- [ ] **Created-by field:** On new/edit forms with `regex-createdby`, non-alphanumeric input is stripped after navigating via Turbo