### PR TITLE
Libappo1 107 replace rails ujs with turbo

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,6 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require rails-ujs
 //= require jquery3
 //= require bootstrap
 //= require gritter

--- a/app/helpers/turbo_link_helper.rb
+++ b/app/helpers/turbo_link_helper.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module TurboLinkHelper
+  DELETE_CONFIRMATION = 'Are you sure?'
+
+  def delete_link(name, url, **options)
+    link_to name, url, **options,
+           data: { turbo_method: :delete, turbo_confirm: DELETE_CONFIRMATION }.merge(options.fetch(:data, {}))
+  end
+
+  def logout_link(name, url, **options)
+    link_to name, url, **options, data: { turbo_method: :delete }.merge(options.fetch(:data, {}))
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,7 +1,4 @@
 // Entry point for esbuild (LIBAPPO1-101). Sprockets still serves legacy JS until #12.
 import "@hotwired/turbo-rails"
-import Rails from "@rails/ujs"
 import "bootstrap/dist/js/bootstrap.bundle"
 import "chart.js/auto"
-
-Rails.start()

--- a/app/views/change_requests/index.html.erb
+++ b/app/views/change_requests/index.html.erb
@@ -54,7 +54,7 @@
               <% else %>
                 <td style="background-color: black ; color: white"><%= link_to 'View', change_request, class: "btn btn-success" %></td>
                 <td style="background-color: black ; color: white"><%= link_to 'Edit', edit_change_request_path(change_request), class: "btn btn-primary" %></td>
-                <td style="background-color: black ; color: white"><%= link_to 'Delete', change_request, class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
+                <td style="background-color: black ; color: white"><%= delete_link 'Delete', change_request, class: "btn btn-danger" %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/change_requests/index.html.erb
+++ b/app/views/change_requests/index.html.erb
@@ -54,7 +54,7 @@
               <% else %>
                 <td style="background-color: black ; color: white"><%= link_to 'View', change_request, class: "btn btn-success" %></td>
                 <td style="background-color: black ; color: white"><%= link_to 'Edit', edit_change_request_path(change_request), class: "btn btn-primary" %></td>
-                <td style="background-color: black ; color: white"><%= link_to 'Delete', change_request, method: :delete, class: "btn btn-danger", data: { confirm: 'Are you sure?' } %></td>
+                <td style="background-color: black ; color: white"><%= link_to 'Delete', change_request, class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/front/dashboard.html.erb
+++ b/app/views/front/dashboard.html.erb
@@ -70,8 +70,7 @@ btn-icons", title: "Edit" }%></td>
 }%></td>
                     <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= link_to 'Edit', edit_software_record_path(record_indesign) , { :class => "btn btn-primary 
 btn-icons", title: "Edit" }%></td>
-                    <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= link_to 'Delete', record_indesign, method: :delete, :class => "btn btn-danger btn-icons", data: 
-{ confirm: 'Are you sure?' }, title: "Delete" %></td>
+                    <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= link_to 'Delete', record_indesign, class: "btn btn-danger btn-icons", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' }, title: "Delete" %></td>
                   <% end %>
                 </tr>
               <% end %>
@@ -157,8 +156,7 @@ btn-icons", title: "Edit" }%></td>
 }%></td>
                     <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= link_to 'Edit', edit_software_record_path(record_production) , { :class => "btn btn-primary 
 btn-icons", title: "Edit" }%></td>
-                    <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= link_to 'Delete', record_production, method: :delete, :class => "btn btn-danger btn-icons", 
-title: "Delete", data: { confirm: 'Are you sure?' } %></td>
+                    <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= link_to 'Delete', record_production, class: "btn btn-danger btn-icons", title: "Delete", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
                   <% end %>
               </tr>
             <% end %>
@@ -245,8 +243,7 @@ btn-icons", title: "Edit" }%></td>
 }%></td>
                     <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= link_to 'Edit', edit_software_record_path(record_production) , { :class => "btn btn-primary 
 btn-icons", title: "Edit" }%></td>
-                    <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= link_to 'Delete', record_production, method: :delete, :class => "btn btn-danger btn-icons", 
-title: "Delete", data: { confirm: 'Are you sure?' } %></td>
+                    <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= link_to 'Delete', record_production, class: "btn btn-danger btn-icons", title: "Delete", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
                   <% end %>
               </tr>
             <% end %>

--- a/app/views/front/dashboard.html.erb
+++ b/app/views/front/dashboard.html.erb
@@ -70,7 +70,7 @@ btn-icons", title: "Edit" }%></td>
 }%></td>
                     <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= link_to 'Edit', edit_software_record_path(record_indesign) , { :class => "btn btn-primary 
 btn-icons", title: "Edit" }%></td>
-                    <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= link_to 'Delete', record_indesign, class: "btn btn-danger btn-icons", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' }, title: "Delete" %></td>
+                    <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= delete_link 'Delete', record_indesign, class: "btn btn-danger btn-icons", title: "Delete" %></td>
                   <% end %>
                 </tr>
               <% end %>
@@ -156,7 +156,7 @@ btn-icons", title: "Edit" }%></td>
 }%></td>
                     <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= link_to 'Edit', edit_software_record_path(record_production) , { :class => "btn btn-primary 
 btn-icons", title: "Edit" }%></td>
-                    <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= link_to 'Delete', record_production, class: "btn btn-danger btn-icons", title: "Delete", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
+                    <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= delete_link 'Delete', record_production, class: "btn btn-danger btn-icons", title: "Delete" %></td>
                   <% end %>
               </tr>
             <% end %>
@@ -243,7 +243,7 @@ btn-icons", title: "Edit" }%></td>
 }%></td>
                     <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= link_to 'Edit', edit_software_record_path(record_production) , { :class => "btn btn-primary 
 btn-icons", title: "Edit" }%></td>
-                    <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= link_to 'Delete', record_production, class: "btn btn-danger btn-icons", title: "Delete", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
+                    <td style="padding: 6px 3px 6px 3px; background-color: black ; color: white"><%= delete_link 'Delete', record_production, class: "btn btn-danger btn-icons", title: "Delete" %></td>
                   <% end %>
               </tr>
             <% end %>

--- a/app/views/front/index.html.erb
+++ b/app/views/front/index.html.erb
@@ -7,7 +7,7 @@
     <p class="lead">
         <% if current_user %>
             <p style="color: white">Logged in as <%= current_user.email %></p>
-            <%= link_to "Logout", destroy_user_session_path, class: "btn btn-dark btn-lg action-btn mx-auto", data: { turbo_method: :delete } %>
+            <%= logout_link "Logout", destroy_user_session_path, class: "btn btn-dark btn-lg action-btn mx-auto" %>
         <% else %>
             <%= link_to "Login", (Rails.configuration.x.auth.shibboleth_enabled ? shibboleth_force_authn_login_path : new_user_session_path), {:class => "btn btn-dark btn-lg mx-auto action-btn"} %>
         <% end %>

--- a/app/views/front/index.html.erb
+++ b/app/views/front/index.html.erb
@@ -7,7 +7,7 @@
     <p class="lead">
         <% if current_user %>
             <p style="color: white">Logged in as <%= current_user.email %></p>
-            <%= link_to "Logout", destroy_user_session_path, :method => :delete, :class => "btn btn-dark btn-lg action-btn mx-auto"%>
+            <%= link_to "Logout", destroy_user_session_path, class: "btn btn-dark btn-lg action-btn mx-auto", data: { turbo_method: :delete } %>
         <% else %>
             <%= link_to "Login", (Rails.configuration.x.auth.shibboleth_enabled ? shibboleth_force_authn_login_path : new_user_session_path), {:class => "btn btn-dark btn-lg mx-auto action-btn"} %>
         <% end %>

--- a/app/views/front/profile.html.erb
+++ b/app/views/front/profile.html.erb
@@ -72,7 +72,7 @@ btn-success" %></td>
 btn-info" %></td>
                     <td style="padding-left: 20px; background-color: black ; color: white"><%= link_to @status, user_status_path(user.id), class: 
 @class %></td>
-                    <td style="padding-left: 20px; background-color: black ; color: white"><%= link_to 'Delete', user_destroy_path(user.id), class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
+                    <td style="padding-left: 20px; background-color: black ; color: white"><%= delete_link 'Delete', user_destroy_path(user.id), class: "btn btn-danger" %></td>
                   </tr>
                 <% end %>
               </tbody>

--- a/app/views/front/profile.html.erb
+++ b/app/views/front/profile.html.erb
@@ -72,9 +72,7 @@ btn-success" %></td>
 btn-info" %></td>
                     <td style="padding-left: 20px; background-color: black ; color: white"><%= link_to @status, user_status_path(user.id), class: 
 @class %></td>
-                    <td style="padding-left: 20px; background-color: black ; color: white"><%= link_to 'Delete', user_destroy_path(user.id), method: 
-:delete, class: "btn btn-danger", data: { confirm: 'Are you sure?' } 
-%></td>
+                    <td style="padding-left: 20px; background-color: black ; color: white"><%= link_to 'Delete', user_destroy_path(user.id), class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
                   </tr>
                 <% end %>
               </tbody>

--- a/app/views/front/search.html.erb
+++ b/app/views/front/search.html.erb
@@ -39,7 +39,7 @@
               <% else %>
                 <td><%= link_to 'View', software_record , { :class => "btn btn-success actions" }%></td>
                 <td><%= link_to 'Edit', edit_software_record_path(software_record), { :class => "btn btn-primary actions" } %></td>
-                <td><%= link_to 'Delete', software_record, class: "btn btn-danger actions", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
+                <td><%= delete_link 'Delete', software_record, class: "btn btn-danger actions" %></td>
               <% end %>
             </tr>
           <% end %>
@@ -78,7 +78,7 @@
               <% else %>
                 <td><%= link_to 'View', software_type , { :class => "btn btn-success actions" }%></td>
                 <td><%= link_to 'Edit', edit_software_type_path(software_type), { :class => "btn btn-primary actions" } %></td>
-                <td><%= link_to 'Delete', software_type, class: "btn btn-danger actions", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
+                <td><%= delete_link 'Delete', software_type, class: "btn btn-danger actions" %></td>
               <% end %>
             </tr>
           <% end %>
@@ -116,7 +116,7 @@
               <% else %>
                 <td><%= link_to 'View', vendor_record , { :class => "btn btn-success actions" }%></td>
                 <td><%= link_to 'Edit', edit_vendor_record_path(vendor_record), { :class => "btn btn-primary actions" } %></td>
-                <td><%= link_to 'Delete', vendor_record, class: "btn btn-danger actions", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
+                <td><%= delete_link 'Delete', vendor_record, class: "btn btn-danger actions" %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/front/search.html.erb
+++ b/app/views/front/search.html.erb
@@ -39,7 +39,7 @@
               <% else %>
                 <td><%= link_to 'View', software_record , { :class => "btn btn-success actions" }%></td>
                 <td><%= link_to 'Edit', edit_software_record_path(software_record), { :class => "btn btn-primary actions" } %></td>
-                <td><%= link_to 'Delete', software_record, method: :delete, :class => "btn btn-danger actions", data: { confirm: 'Are you sure?' } %></td>
+                <td><%= link_to 'Delete', software_record, class: "btn btn-danger actions", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
               <% end %>
             </tr>
           <% end %>
@@ -78,7 +78,7 @@
               <% else %>
                 <td><%= link_to 'View', software_type , { :class => "btn btn-success actions" }%></td>
                 <td><%= link_to 'Edit', edit_software_type_path(software_type), { :class => "btn btn-primary actions" } %></td>
-                <td><%= link_to 'Delete', software_type, method: :delete, :class => "btn btn-danger actions", data: { confirm: 'Are you sure?' } %></td>
+                <td><%= link_to 'Delete', software_type, class: "btn btn-danger actions", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
               <% end %>
             </tr>
           <% end %>
@@ -116,7 +116,7 @@
               <% else %>
                 <td><%= link_to 'View', vendor_record , { :class => "btn btn-success actions" }%></td>
                 <td><%= link_to 'Edit', edit_vendor_record_path(vendor_record), { :class => "btn btn-primary actions" } %></td>
-                <td><%= link_to 'Delete', vendor_record, method: :delete, :class => "btn btn-danger actions", data: { confirm: 'Are you sure?' } %></td>
+                <td><%= link_to 'Delete', vendor_record, class: "btn btn-danger actions", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/hosting_environments/index.html.erb
+++ b/app/views/hosting_environments/index.html.erb
@@ -46,7 +46,7 @@
               <% else %>
                 <td style="background-color: black ; color: white"><%= link_to 'View', hosting_environment, class: "btn btn-success" %></td>
                 <td style="background-color: black ; color: white"><%= link_to 'Edit', edit_hosting_environment_path(hosting_environment), class: "btn btn-primary" %></td>
-                <td style="background-color: black ; color: white"><%= link_to 'Delete', hosting_environment, method: :delete, class: "btn btn-danger", data: { confirm: 'Are you sure?' } %></td>
+                <td style="background-color: black ; color: white"><%= link_to 'Delete', hosting_environment, class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/hosting_environments/index.html.erb
+++ b/app/views/hosting_environments/index.html.erb
@@ -46,7 +46,7 @@
               <% else %>
                 <td style="background-color: black ; color: white"><%= link_to 'View', hosting_environment, class: "btn btn-success" %></td>
                 <td style="background-color: black ; color: white"><%= link_to 'Edit', edit_hosting_environment_path(hosting_environment), class: "btn btn-primary" %></td>
-                <td style="background-color: black ; color: white"><%= link_to 'Delete', hosting_environment, class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
+                <td style="background-color: black ; color: white"><%= delete_link 'Delete', hosting_environment, class: "btn btn-danger" %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/shared/_application_nav.html.erb
+++ b/app/views/shared/_application_nav.html.erb
@@ -9,7 +9,7 @@
       			<%= current_user.first_name.to_s+" "+current_user.last_name.to_s %>
     			</a>
     			<div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-  			    <%= link_to "Logout", destroy_user_session_path, class: "nav-link dropdown-item", data: { turbo_method: :delete } %>
+  			    <%= logout_link "Logout", destroy_user_session_path, class: "nav-link dropdown-item" %>
   			  </div>
   		  </div>
       <% else %>

--- a/app/views/shared/_application_nav.html.erb
+++ b/app/views/shared/_application_nav.html.erb
@@ -9,7 +9,7 @@
       			<%= current_user.first_name.to_s+" "+current_user.last_name.to_s %>
     			</a>
     			<div class="dropdown-menu" aria-labelledby="dropdownMenuLink">
-  			    <%= link_to "Logout", destroy_user_session_path, :method => :delete, :class => "nav-link dropdown-item"%>
+  			    <%= link_to "Logout", destroy_user_session_path, class: "nav-link dropdown-item", data: { turbo_method: :delete } %>
   			  </div>
   		  </div>
       <% else %>

--- a/app/views/shared/_dashboard_header.html.erb
+++ b/app/views/shared/_dashboard_header.html.erb
@@ -24,7 +24,7 @@
        		<div class="dropdown-content bg-black">
        			<a href="<%= myprofile_path %>" class="text-white">My Profile <i class="fa fa-user float-right"></i></a>
     			  <% if current_user %>
-              <%= link_to "Logout", destroy_user_session_path, class: "text-white", data: { turbo_method: :delete } %>
+              <%= logout_link "Logout", destroy_user_session_path, class: "text-white" %>
             <%end%>
        		</div>
        </div>

--- a/app/views/shared/_dashboard_header.html.erb
+++ b/app/views/shared/_dashboard_header.html.erb
@@ -24,7 +24,7 @@
        		<div class="dropdown-content bg-black">
        			<a href="<%= myprofile_path %>" class="text-white">My Profile <i class="fa fa-user float-right"></i></a>
     			  <% if current_user %>
-              <%= link_to "Logout", destroy_user_session_path, :method => :delete, :class => "text-white" %>
+              <%= link_to "Logout", destroy_user_session_path, class: "text-white", data: { turbo_method: :delete } %>
             <%end%>
        		</div>
        </div>

--- a/app/views/software_records/_change_management.html.erb
+++ b/app/views/software_records/_change_management.html.erb
@@ -51,7 +51,7 @@
               <% else %>
                 <td><%= link_to 'View', change_request , { :class => "btn btn-success" }%></td>
                 <td><%= link_to 'Edit', edit_change_request_path(change_request), { :class => "btn btn-primary" } %></td>
-                <td><%= link_to 'Delete', change_request, method: :delete, :class => "btn btn-danger", data: { confirm: 'Are you sure?' } %></td>
+                <td><%= link_to 'Delete', change_request, class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/software_records/_change_management.html.erb
+++ b/app/views/software_records/_change_management.html.erb
@@ -51,7 +51,7 @@
               <% else %>
                 <td><%= link_to 'View', change_request , { :class => "btn btn-success" }%></td>
                 <td><%= link_to 'Edit', edit_change_request_path(change_request), { :class => "btn btn-primary" } %></td>
-                <td><%= link_to 'Delete', change_request, class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
+                <td><%= delete_link 'Delete', change_request, class: "btn btn-danger" %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/software_records/_upgrade_history.html.erb
+++ b/app/views/software_records/_upgrade_history.html.erb
@@ -36,7 +36,7 @@ Upgrade history (Completed Change Request)
               <% else %>
                 <td><%= link_to 'View', change_request , { :class => "btn btn-success" }%></td>
                 <td><%= link_to 'Edit', edit_change_request_path(change_request), { :class => "btn btn-primary" } %></td>
-                <td><%= link_to 'Delete', change_request, class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
+                <td><%= delete_link 'Delete', change_request, class: "btn btn-danger" %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/software_records/_upgrade_history.html.erb
+++ b/app/views/software_records/_upgrade_history.html.erb
@@ -36,7 +36,7 @@ Upgrade history (Completed Change Request)
               <% else %>
                 <td><%= link_to 'View', change_request , { :class => "btn btn-success" }%></td>
                 <td><%= link_to 'Edit', edit_change_request_path(change_request), { :class => "btn btn-primary" } %></td>
-                <td><%= link_to 'Delete', change_request, method: :delete, :class => "btn btn-danger", data: { confirm: 'Are you sure?' } %></td>
+                <td><%= link_to 'Delete', change_request, class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/software_records/index.html.erb
+++ b/app/views/software_records/index.html.erb
@@ -113,7 +113,7 @@ generate_path(software_record.production_url) %> target="_blank" ><%= clean_url(
               <% else %>
                 <td style="background-color: black ; color: white"><%= link_to 'View', software_record , { :class => "btn btn-success action-btn" }%></td>
                 <td style="background-color: black ; color: white"><%= link_to 'Edit', edit_software_record_path(software_record), { :class => "btn btn-primary action-btn" } %></td>
-                <td style="background-color: black ; color: white"><%= link_to 'Delete', software_record, class: "btn btn-danger action-btn", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
+                <td style="background-color: black ; color: white"><%= delete_link 'Delete', software_record, class: "btn btn-danger action-btn" %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/software_records/index.html.erb
+++ b/app/views/software_records/index.html.erb
@@ -113,8 +113,7 @@ generate_path(software_record.production_url) %> target="_blank" ><%= clean_url(
               <% else %>
                 <td style="background-color: black ; color: white"><%= link_to 'View', software_record , { :class => "btn btn-success action-btn" }%></td>
                 <td style="background-color: black ; color: white"><%= link_to 'Edit', edit_software_record_path(software_record), { :class => "btn btn-primary action-btn" } %></td>
-                <td style="background-color: black ; color: white"><%= link_to 'Delete', software_record, method: :delete, :class => "btn btn-danger action-btn", data: { confirm: 'Are you sure?' } 
-%></td>
+                <td style="background-color: black ; color: white"><%= link_to 'Delete', software_record, class: "btn btn-danger action-btn", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/software_records/list_upgrades.html.erb
+++ b/app/views/software_records/list_upgrades.html.erb
@@ -147,7 +147,7 @@ onclick="clearFiltersAndRedirect('list_upgrades')">Clear all filters <i class="f
         <% else %>
           <td style="background-color: black; color: white"><%= link_to 'View', software_record, class: "btn btn-success" %></td>
           <td style="background-color: black ; color: white"><%= link_to 'Edit', "#{edit_software_record_path(software_record)}#maintenance-log", class: "btn btn-primary" %></td>
-          <td style="background-color: black; color: white"><%= link_to 'Delete', software_record, class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
+          <td style="background-color: black; color: white"><%= delete_link 'Delete', software_record, class: "btn btn-danger" %></td>
 
         <% end %>
       </tr>

--- a/app/views/software_records/list_upgrades.html.erb
+++ b/app/views/software_records/list_upgrades.html.erb
@@ -147,7 +147,7 @@ onclick="clearFiltersAndRedirect('list_upgrades')">Clear all filters <i class="f
         <% else %>
           <td style="background-color: black; color: white"><%= link_to 'View', software_record, class: "btn btn-success" %></td>
           <td style="background-color: black ; color: white"><%= link_to 'Edit', "#{edit_software_record_path(software_record)}#maintenance-log", class: "btn btn-primary" %></td>
-          <td style="background-color: black; color: white"><%= link_to 'Delete', software_record, method: :delete, class: "btn btn-danger", data: { confirm: 'Are you sure?' } %></td>
+          <td style="background-color: black; color: white"><%= link_to 'Delete', software_record, class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
 
         <% end %>
       </tr>

--- a/app/views/software_types/index.html.erb
+++ b/app/views/software_types/index.html.erb
@@ -46,7 +46,7 @@
               <% else %>
                 <td style="background-color: black ; color: white"><%= link_to 'View', software_type, class: "btn btn-success" %></td>
                 <td style="background-color: black ; color: white"><%= link_to 'Edit', edit_software_type_path(software_type), class: "btn btn-primary" %></td>
-                <td style="background-color: black ; color: white"><%= link_to 'Delete', software_type, method: :delete, class: "btn btn-danger", data: { confirm: 'Are you sure?' } %></td>
+                <td style="background-color: black ; color: white"><%= link_to 'Delete', software_type, class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/software_types/index.html.erb
+++ b/app/views/software_types/index.html.erb
@@ -46,7 +46,7 @@
               <% else %>
                 <td style="background-color: black ; color: white"><%= link_to 'View', software_type, class: "btn btn-success" %></td>
                 <td style="background-color: black ; color: white"><%= link_to 'Edit', edit_software_type_path(software_type), class: "btn btn-primary" %></td>
-                <td style="background-color: black ; color: white"><%= link_to 'Delete', software_type, class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
+                <td style="background-color: black ; color: white"><%= delete_link 'Delete', software_type, class: "btn btn-danger" %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/statuses/index.html.erb
+++ b/app/views/statuses/index.html.erb
@@ -46,7 +46,7 @@
               <% else %>
                 <td style="background-color: black ; color: white"><%= link_to 'View', status, class: "btn btn-success" %></td>
                 <td style="background-color: black ; color: white"><%= link_to 'Edit', edit_status_path(status), class: "btn btn-primary" %></td>
-                <td style="background-color: black ; color: white"><%= link_to 'Delete', status, method: :delete, class: "btn btn-danger", data: { confirm: 'Are you sure?' } %></td>
+                <td style="background-color: black ; color: white"><%= link_to 'Delete', status, class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/statuses/index.html.erb
+++ b/app/views/statuses/index.html.erb
@@ -46,7 +46,7 @@
               <% else %>
                 <td style="background-color: black ; color: white"><%= link_to 'View', status, class: "btn btn-success" %></td>
                 <td style="background-color: black ; color: white"><%= link_to 'Edit', edit_status_path(status), class: "btn btn-primary" %></td>
-                <td style="background-color: black ; color: white"><%= link_to 'Delete', status, class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
+                <td style="background-color: black ; color: white"><%= delete_link 'Delete', status, class: "btn btn-danger" %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -26,7 +26,7 @@
                     <td style="background-color: black ; color: white"><%= link_to 'View', users_show_path(user.id) , { :class => "btn btn-success" }%></td>
                     <td style="background-color: black ; color: white"><%= link_to 'Edit', user_edit_path(user.id) , { :class => "btn btn-info" }%></td>
                     <td style="background-color: black ; color: white"><%= link_to @status, user_status_path(user.id) , { :class => @class }%></td>
-                    <td style="background-color: black ; color: white"><%= link_to 'Delete', user_destroy_path(user.id), class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
+                    <td style="background-color: black ; color: white"><%= delete_link 'Delete', user_destroy_path(user.id), class: "btn btn-danger" %></td>
                   </tr>
                 <% end %>
               </tbody>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -26,8 +26,7 @@
                     <td style="background-color: black ; color: white"><%= link_to 'View', users_show_path(user.id) , { :class => "btn btn-success" }%></td>
                     <td style="background-color: black ; color: white"><%= link_to 'Edit', user_edit_path(user.id) , { :class => "btn btn-info" }%></td>
                     <td style="background-color: black ; color: white"><%= link_to @status, user_status_path(user.id) , { :class => @class }%></td>
-                    <td style="background-color: black ; color: white"><%= link_to 'Delete', user_destroy_path(user.id), method: :delete, :class => "btn btn-danger", data: { confirm: 'Are you 
-sure?' } %></td>
+                    <td style="background-color: black ; color: white"><%= link_to 'Delete', user_destroy_path(user.id), class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
                   </tr>
                 <% end %>
               </tbody>

--- a/app/views/vendor_records/index.html.erb
+++ b/app/views/vendor_records/index.html.erb
@@ -46,8 +46,7 @@
               <% else %>
                 <td style="padding-left: 20px; background-color: black ; color: white"><%= link_to 'View', vendor_record, class: "btn btn-success" %></td>
                 <td style="padding-left: 20px; background-color: black ; color: white"><%= link_to 'Edit', edit_vendor_record_path(vendor_record), class: "btn btn-primary" %></td>
-                <td style="padding-left: 20px; background-color: black ; color: white"><%= link_to 'Delete', vendor_record, method: :delete, class: "btn btn-danger", data: { confirm: 'Are you 
-sure?' } %></td>
+                <td style="padding-left: 20px; background-color: black ; color: white"><%= link_to 'Delete', vendor_record, class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
               <% end %>
             </tr>
           <% end %>

--- a/app/views/vendor_records/index.html.erb
+++ b/app/views/vendor_records/index.html.erb
@@ -46,7 +46,7 @@
               <% else %>
                 <td style="padding-left: 20px; background-color: black ; color: white"><%= link_to 'View', vendor_record, class: "btn btn-success" %></td>
                 <td style="padding-left: 20px; background-color: black ; color: white"><%= link_to 'Edit', edit_vendor_record_path(vendor_record), class: "btn btn-primary" %></td>
-                <td style="padding-left: 20px; background-color: black ; color: white"><%= link_to 'Delete', vendor_record, class: "btn btn-danger", data: { turbo_method: :delete, turbo_confirm: 'Are you sure?' } %></td>
+                <td style="padding-left: 20px; background-color: black ; color: white"><%= delete_link 'Delete', vendor_record, class: "btn btn-danger" %></td>
               <% end %>
             </tr>
           <% end %>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "@hotwired/turbo-rails": "^8.0.23",
     "@popperjs/core": "^2.11.8",
-    "@rails/ujs": "^7.1.3-4",
     "bootstrap": "^5.3.3",
     "chart.js": "^4.4.8"
   },

--- a/spec/build/javascript_build_spec.rb
+++ b/spec/build/javascript_build_spec.rb
@@ -20,5 +20,6 @@ RSpec.describe 'esbuild javascript build' do
     expect(bundle).to exist
     expect(bundle.size).to be > 1000
     expect(bundle.read).to match(/turbo/i)
+    expect(bundle.read).not_to include('@rails/ujs')
   end
 end

--- a/spec/helpers/turbo_link_helper_spec.rb
+++ b/spec/helpers/turbo_link_helper_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe TurboLinkHelper, type: :helper do
+  describe '#delete_link' do
+    it 'renders a Turbo DELETE link with confirmation' do
+      link = delete_link('Delete', '/records/1', class: 'btn btn-danger')
+
+      expect(link).to include('data-turbo-method="delete"')
+      expect(link).to include('data-turbo-confirm="Are you sure?"')
+      expect(link).to include('class="btn btn-danger"')
+    end
+  end
+
+  describe '#logout_link' do
+    it 'renders a Turbo DELETE link without confirmation' do
+      link = logout_link('Logout', '/users/sign_out', class: 'text-white')
+
+      expect(link).to include('data-turbo-method="delete"')
+      expect(link).not_to include('data-turbo-confirm')
+      expect(link).to include('class="text-white"')
+    end
+  end
+end

--- a/spec/views/front/index.html.erb_spec.rb
+++ b/spec/views/front/index.html.erb_spec.rb
@@ -47,6 +47,7 @@ describe 'front/index' do
     it 'displays a logout link' do
       render
       expect(rendered).to have_link('Logout', href: destroy_user_session_path)
+      assert_select 'a[data-turbo-method=delete]', text: 'Logout'
     end
   end
 end

--- a/spec/views/index.html.erb_spec.rb
+++ b/spec/views/index.html.erb_spec.rb
@@ -47,6 +47,7 @@ describe 'front/index' do
     it 'displays a logout link' do
       render
       expect(rendered).to have_link('Logout', href: destroy_user_session_path)
+      assert_select 'a[data-turbo-method=delete]', text: 'Logout'
     end
   end
 end

--- a/spec/views/software_records/index.html.erb_spec.rb
+++ b/spec/views/software_records/index.html.erb_spec.rb
@@ -66,4 +66,10 @@ RSpec.describe 'software_records/index', type: :view do
     render
     expect(rendered).to have_text('Vendor Filter')
   end
+
+  it 'renders delete links with Turbo method and confirm' do
+    render
+
+    assert_select 'a.btn-danger[data-turbo-method=delete][data-turbo-confirm]', minimum: 1
+  end
 end


### PR DESCRIPTION
## Summary

- Removes `rails-ujs` / `@rails/ujs` from the Sprockets manifest, esbuild bundle, and `package.json`; Turbo (already loaded as a module in layouts) now handles non-GET link actions.
- Migrates 22 delete links and 4 logout links from `method: :delete` / `data-confirm` to Turbo (`data-turbo-method`, `data-turbo-confirm` where applicable).
- Adds `TurboLinkHelper` with `delete_link` and `logout_link` so Turbo data attributes live in one place across 16 views.
- Adds helper and view specs; build spec asserts the esbuild bundle includes Turbo and no longer includes `@rails/ujs`.

## Test plan

- [x] `bundle exec rubocop`
- [x] `bundle exec rspec` (552 examples, 0 failures)
- [ ] On QA: click a **Delete** link on an index page — confirm dialog appears; record is removed on confirm
- [ ] On QA: **Logout** from nav, dashboard header, and front index — session ends without a confirm prompt
- [ ] Smoke-check a few admin tables (software records, users, change requests) that delete links still render and behave correctly