### PR TITLE
Libappo1 104 replace gritter flash plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,8 +66,6 @@ gem 'jquery-rails'
 gem 'dotenv-rails'
 # Use petergate for authorization
 gem 'petergate'
-# Use gritter for flash message
-gem 'gritter'
 # Use chartkick for data-visualization techniques
 gem 'chartkick', '~> 5.2'
 # Use groupdate to group by dates

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,6 @@ GEM
     google-protobuf (4.35.1-x86_64-linux-gnu)
       bigdecimal
       rake (~> 13.3)
-    gritter (1.2.0)
     groupdate (6.8.0)
       activesupport (>= 7.2)
     i18n (1.15.1)
@@ -500,7 +499,6 @@ DEPENDENCIES
   factory_bot_rails
   foreman
   globalize (~> 7.0)
-  gritter
   groupdate
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,7 +12,6 @@
 //
 //= require jquery3
 //= require bootstrap
-//= require gritter
 //= require activestorage
 //= require chartkick
 //= require Chart.bundle

--- a/app/assets/javascripts/flash_toasts.js
+++ b/app/assets/javascripts/flash_toasts.js
@@ -1,0 +1,7 @@
+document.addEventListener("turbo:load", function () {
+  if (typeof bootstrap === "undefined") return;
+
+  document.querySelectorAll(".flash-toast").forEach(function (element) {
+    bootstrap.Toast.getOrCreateInstance(element).show();
+  });
+});

--- a/app/assets/stylesheets/_dashboard_base.scss
+++ b/app/assets/stylesheets/_dashboard_base.scss
@@ -33,7 +33,8 @@ option {
   padding: 0 24px;
 }
 
-.gritter {
-  right: -10px;
+.flash-toast-container {
   top: 70px;
+  right: 10px;
+  z-index: 1100;
 }

--- a/app/assets/stylesheets/_gem_dependencies.scss
+++ b/app/assets/stylesheets/_gem_dependencies.scss
@@ -1,10 +1,4 @@
-// Shared Bootstrap + gritter imports for dartsass entry points.
-//
-// The gritter gem names its stylesheet gritter.css.scss — use that exact import
-// path so Dart Sass inlines it at compile time. @import "gritter.css" emits a
-// runtime CSS @import that Sprockets cannot resolve (the browser loads Rails
-// HTML as CSS and layout breaks).
+// Shared Bootstrap imports for dartsass entry points.
 $enable-responsive-font-sizes: false;
 
-@import "gritter.css.scss";
 @import "bootstrap";

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,31 +3,6 @@
 require 'cgi'
 
 module ApplicationHelper
-  def alerts
-    if flash[:alert]
-      alert_generator flash[:alert], 'alert'
-    elsif flash[:notice]
-      alert_generator flash[:notice], 'notice'
-    elsif flash[:error]
-      alert_generator flash[:error], 'error'
-    else
-      alert_generator flash, 'warning'
-    end
-  end
-
-  def alert_generator(msg, type)
-    case type
-    when 'alert'
-      js add_gritter(msg, title: 'UCL Application Portfolio', image: :notice, time: 3000, class_name: 'gritter')
-    when 'notice'
-      js add_gritter(msg, title: 'UCL Application Portfolio', image: :progress, time: 3000, class_name: 'gritter')
-    when 'error'
-      js add_gritter(msg, title: 'UCL Application Portfolio', image: :error, time: 3000, class_name: 'gritter')
-    else
-      js add_gritter(flash[:warning], title: 'UCL Application Portfolio', image: :warning, time: 3000, class_name: 'gritter')
-    end
-  end
-
   def nav_helper(style)
     if current_user
       (link_to 'Dashboard', dashboard_path, class: "#{style} #{active? dashboard_path}") + ' '.html_safe +

--- a/app/helpers/flash_messages_helper.rb
+++ b/app/helpers/flash_messages_helper.rb
@@ -14,11 +14,11 @@ module FlashMessagesHelper
   }.freeze
 
   def alerts
-    messages = flash_toast_messages
-    return if messages.empty?
+    toasts = flash_toast_entries
+    return if toasts.empty?
 
     render 'shared/alerts',
-           flash_messages: messages,
+           flash_toasts: toasts,
            app_title: FLASH_APP_TITLE,
            toast_delay: FLASH_TOAST_DELAY_MS
   end
@@ -31,13 +31,14 @@ module FlashMessagesHelper
     sanitize(message.to_s, tags: FLASH_ALLOWED_TAGS)
   end
 
-  def flash_toast_style(type)
-    FLASH_TOAST_TYPES.fetch(type)
-  end
-
   private
 
-  def flash_toast_messages
-    FLASH_TOAST_TYPES.filter_map { |type, _| [type, flash[type]] if flash[type].present? }
+  def flash_toast_entries
+    FLASH_TOAST_TYPES.filter_map do |type, style|
+      message = flash[type]
+      next if message.blank?
+
+      style.merge(message: message)
+    end
   end
 end

--- a/app/helpers/flash_messages_helper.rb
+++ b/app/helpers/flash_messages_helper.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module FlashMessagesHelper
+  FLASH_APP_TITLE = 'UCL Application Portfolio'
+  FLASH_TOAST_DELAY_MS = 3000
+  FLASH_ALLOWED_TAGS = %w[br].freeze
+
+  FLASH_TOAST_TYPES = {
+    'success' => { icon: 'fa-check-circle', header_class: 'text-success' },
+    'notice' => { icon: 'fa-info-circle', header_class: 'text-info' },
+    'alert' => { icon: 'fa-exclamation-triangle', header_class: 'text-warning' },
+    'error' => { icon: 'fa-times-circle', header_class: 'text-danger' },
+    'warning' => { icon: 'fa-exclamation-triangle', header_class: 'text-warning' }
+  }.freeze
+
+  def alerts
+    messages = flash_toast_messages
+    return if messages.empty?
+
+    render 'shared/alerts',
+           flash_messages: messages,
+           app_title: FLASH_APP_TITLE,
+           toast_delay: FLASH_TOAST_DELAY_MS
+  end
+
+  def form_error_alert(message)
+    content_tag(:div, flash_message_body(message), class: 'alert alert-danger mb-2', role: 'alert')
+  end
+
+  def flash_message_body(message)
+    sanitize(message.to_s, tags: FLASH_ALLOWED_TAGS)
+  end
+
+  def flash_toast_style(type)
+    FLASH_TOAST_TYPES.fetch(type)
+  end
+
+  private
+
+  def flash_toast_messages
+    FLASH_TOAST_TYPES.filter_map { |type, _| [type, flash[type]] if flash[type].present? }
+  end
+end

--- a/app/views/change_requests/_form.html.erb
+++ b/app/views/change_requests/_form.html.erb
@@ -7,7 +7,7 @@
         <% if change_request.errors.any? %>
           <div id="error_explanation">
             <% change_request.errors.full_messages.each do |message| %>
-              <%= alert_generator message, "error" %>
+              <%= form_error_alert(message) %>
             <% end %>
           </div>
         <% end %>

--- a/app/views/change_requests/_form.html.erb
+++ b/app/views/change_requests/_form.html.erb
@@ -4,13 +4,7 @@
     <hr style="background-color: white">
     <div class = "card-body">
       <%= form_with(model: change_request, local: true) do |form| %>
-        <% if change_request.errors.any? %>
-          <div id="error_explanation">
-            <% change_request.errors.full_messages.each do |message| %>
-              <%= form_error_alert(message) %>
-            <% end %>
-          </div>
-        <% end %>
+        <%= render 'shared/form_errors', object: change_request %>
 
         <div class="field">
           <%= form.label :change_title %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,7 +1,1 @@
-<% if resource.errors.any? %>
-  <div id="error_explanation">
-    <% resource.errors.full_messages.each do |message| %>
-      <%= form_error_alert(message) %>
-    <% end %>
-  </div>
-<% end %>
+<%= render 'shared/form_errors', object: resource %>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,15 +1,7 @@
 <% if resource.errors.any? %>
   <div id="error_explanation">
-   <!-- <h2>
-      <%= I18n.t("errors.messages.not_saved",
-                 count: resource.errors.count,
-                 resource: resource.class.model_name.human.downcase)
-       %>
-    </h2> -->
-    <ul>
-      <% resource.errors.full_messages.each do |message| %>
-        <%= alert_generator message, "error" %>
-      <% end %>
-    </ul>
+    <% resource.errors.full_messages.each do |message| %>
+      <%= form_error_alert(message) %>
+    <% end %>
   </div>
 <% end %>

--- a/app/views/hosting_environments/_form.html.erb
+++ b/app/views/hosting_environments/_form.html.erb
@@ -7,7 +7,7 @@
         <% if hosting_environment.errors.any? %>
           <div id="error_explanation">
             <% hosting_environment.errors.full_messages.each do |message| %>
-              <%= alert_generator message, "error" %>
+              <%= form_error_alert(message) %>
             <% end %>
           </div>
         <% end %>

--- a/app/views/hosting_environments/_form.html.erb
+++ b/app/views/hosting_environments/_form.html.erb
@@ -4,13 +4,7 @@
     <hr style="background-color: white">
     <div class = "card-body">
       <%= form_with(model: hosting_environment, local: true) do |form| %>
-        <% if hosting_environment.errors.any? %>
-          <div id="error_explanation">
-            <% hosting_environment.errors.full_messages.each do |message| %>
-              <%= form_error_alert(message) %>
-            <% end %>
-          </div>
-        <% end %>
+          <%= render 'shared/form_errors', object: hosting_environment %>
 
         <div class="field">
           <%= form.label :title, class: 'text-white' %>

--- a/app/views/shared/_alerts.html.erb
+++ b/app/views/shared/_alerts.html.erb
@@ -1,17 +1,16 @@
-<% if flash_messages.any? %>
+<% if flash_toasts.any? %>
   <div class="toast-container flash-toast-container position-fixed end-0 p-3" aria-live="polite" aria-atomic="true">
-    <% flash_messages.each do |type, message| %>
-      <% options = flash_toast_style(type) %>
+    <% flash_toasts.each do |toast| %>
       <div class="toast flash-toast text-bg-dark border-0 mb-2" role="alert"
            data-bs-autohide="true" data-bs-delay="<%= toast_delay %>"
            aria-live="assertive" aria-atomic="true">
         <div class="toast-header text-bg-dark border-secondary">
-          <i class="fas <%= options[:icon] %> <%= options[:header_class] %> me-2" aria-hidden="true"></i>
+          <i class="fas <%= toast[:icon] %> <%= toast[:header_class] %> me-2" aria-hidden="true"></i>
           <strong class="me-auto"><%= app_title %></strong>
           <button type="button" class="btn-close btn-close-white" data-bs-dismiss="toast" aria-label="Close"></button>
         </div>
         <div class="toast-body">
-          <%= flash_message_body(message) %>
+          <%= flash_message_body(toast[:message]) %>
         </div>
       </div>
     <% end %>

--- a/app/views/shared/_alerts.html.erb
+++ b/app/views/shared/_alerts.html.erb
@@ -1,11 +1,19 @@
-<% if flash[:success] %>
-	<%= js add_gritter(flash[:success], :title => "UCL Application Portfolio", :image => :success, :time => 3000, :class_name => "gritter") %>
-<% elsif flash[:warning] %>
-	<%= js add_gritter(flash[:warning], :title => "UCL Application Portfolio", :image => :warning, :time => 3000, :class_name => "gritter") %>
-<% elsif flash[:alert] %>
-	<%= js add_gritter(flash[:alert], :title => "UCL Application Portfolio", :image => :notice, :time => 3000, :class_name => "gritter") %>
-<% elsif flash[:error] %>
-	<%= js add_gritter(flash[:error], :title => "UCL Application Portfolio", :image => :error, :time => 3000, :class_name => "gritter") %>
-<% else flash[:notice] %>
-	<%= js add_gritter(flash[:notice], :title => "UCL Application Portfolio", :image => :progress, :time => 3000, :class_name => "gritter") %>
+<% if flash_messages.any? %>
+  <div class="toast-container flash-toast-container position-fixed end-0 p-3" aria-live="polite" aria-atomic="true">
+    <% flash_messages.each do |type, message| %>
+      <% options = flash_toast_style(type) %>
+      <div class="toast flash-toast text-bg-dark border-0 mb-2" role="alert"
+           data-bs-autohide="true" data-bs-delay="<%= toast_delay %>"
+           aria-live="assertive" aria-atomic="true">
+        <div class="toast-header text-bg-dark border-secondary">
+          <i class="fas <%= options[:icon] %> <%= options[:header_class] %> me-2" aria-hidden="true"></i>
+          <strong class="me-auto"><%= app_title %></strong>
+          <button type="button" class="btn-close btn-close-white" data-bs-dismiss="toast" aria-label="Close"></button>
+        </div>
+        <div class="toast-body">
+          <%= flash_message_body(message) %>
+        </div>
+      </div>
+    <% end %>
+  </div>
 <% end %>

--- a/app/views/shared/_form_errors.html.erb
+++ b/app/views/shared/_form_errors.html.erb
@@ -1,0 +1,7 @@
+<% if object.errors.any? %>
+  <div id="error_explanation">
+    <% object.errors.full_messages.each do |message| %>
+      <%= form_error_alert(message) %>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/software_records/_form.html.erb
+++ b/app/views/software_records/_form.html.erb
@@ -39,7 +39,7 @@
         <% if software_record.errors.any? %>
           <div id="error_explanation">
             <% software_record.errors.full_messages.each do |message| %>
-              <%= alert_generator message, "error" %>
+              <%= form_error_alert(message) %>
             <% end %>
           </div>
         <% end %>

--- a/app/views/software_records/_form.html.erb
+++ b/app/views/software_records/_form.html.erb
@@ -36,13 +36,7 @@
       </ul>
 
       <div class="card-body">
-        <% if software_record.errors.any? %>
-          <div id="error_explanation">
-            <% software_record.errors.full_messages.each do |message| %>
-              <%= form_error_alert(message) %>
-            <% end %>
-          </div>
-        <% end %>
+          <%= render 'shared/form_errors', object: software_record %>
         <div class="tab-content" id="softwareRecordsTabContent">
           <div class="tab-pane fade show active" id="general" role="tabpanel" aria-labelledby="general-tab">
             <%= render 'form_general', software_record: @software_record, component: component, form: form %>

--- a/app/views/software_records/edit_road_map.html.erb
+++ b/app/views/software_records/edit_road_map.html.erb
@@ -5,16 +5,7 @@
     <h1 class="text-center" style="color: white;">Edit Road Map</h1>
 
     <%= form_with(model: @software_record, url: update_road_map_software_record_path(@software_record), local: true, class: 'mt-4') do |form| %>
-      <% if @software_record.errors.any? %>
-        <div id="error_explanation" class="alert alert-danger">
-          <h2><%= pluralize(@software_record.errors.count, "error") %> prohibited this road map from being saved:</h2>
-          <ul>
-            <% @software_record.errors.full_messages.each do |message| %>
-              <li><%= message %></li>
-            <% end %>
-          </ul>
-        </div>
-      <% end %>
+      <%= render 'shared/form_errors', object: @software_record %>
 
       <% if !@software_record.title.nil? && !@software_record.title.to_s.empty? %> 
         <div class="mb-3">

--- a/app/views/software_types/_form.html.erb
+++ b/app/views/software_types/_form.html.erb
@@ -7,7 +7,7 @@
           <% if software_type.errors.any? %>
             <div id="error_explanation">
               <% software_type.errors.full_messages.each do |message| %>
-                <%= alert_generator message, "error" %>
+                <%= form_error_alert(message) %>
               <% end %>
             </div>
           <% end %>

--- a/app/views/software_types/_form.html.erb
+++ b/app/views/software_types/_form.html.erb
@@ -4,13 +4,7 @@
     <h1 class= "<%= component %> text-center" style="color: white;"><% if component.eql?("new") %>New Software Type<% else %>Edit Software Type<% end %></h1>
     <div class = "card-body">
         <%= form_with(model: software_type, local: true) do |form| %>
-          <% if software_type.errors.any? %>
-            <div id="error_explanation">
-              <% software_type.errors.full_messages.each do |message| %>
-                <%= form_error_alert(message) %>
-              <% end %>
-            </div>
-          <% end %>
+            <%= render 'shared/form_errors', object: software_type %>
         <div class="mb-3">
           <%= form.label :title, 'Software Type', class: 'text-white' %>
           <%= form.text_field :title, :class => "form-control" %>

--- a/app/views/statuses/_form.html.erb
+++ b/app/views/statuses/_form.html.erb
@@ -7,7 +7,7 @@
         <% if status.errors.any? %>
           <div id="error_explanation">
             <% status.errors.full_messages.each do |message| %>
-              <%= alert_generator message, "error" %>
+              <%= form_error_alert(message) %>
             <% end %>
           </div>
         <% end %>

--- a/app/views/statuses/_form.html.erb
+++ b/app/views/statuses/_form.html.erb
@@ -4,13 +4,7 @@
     <hr style="background-color: white">
     <div class = "card-body">
       <%= form_with(model: status, local: true) do |form| %>
-        <% if status.errors.any? %>
-          <div id="error_explanation">
-            <% status.errors.full_messages.each do |message| %>
-              <%= form_error_alert(message) %>
-            <% end %>
-          </div>
-        <% end %>
+          <%= render 'shared/form_errors', object: status %>
 
         <div class="field">
           <%= form.label :title, class: 'text-white' %>

--- a/app/views/vendor_records/_form.html.erb
+++ b/app/views/vendor_records/_form.html.erb
@@ -4,13 +4,7 @@
     <h1 class= "<%= component %> text-center" style="color: white;"><% if component.eql?("new") %>New Vendor Record<% else %>Edit Vendor Record<% end %></h1>
     <div class = "card-body">
         <%= form_with(model: vendor_record, local: true) do |form| %>
-          <% if vendor_record.errors.any? %>
-            <div id="error_explanation">
-              <% vendor_record.errors.full_messages.each do |message| %>
-                <%= form_error_alert(message) %>
-              <% end %>
-            </div>
-          <% end %>
+            <%= render 'shared/form_errors', object: vendor_record %>
         <div class="mb-3">
           <%= form.label :title, 'Name', class: 'text-white' %>
           <%= form.text_field :title, :class => "form-control" %>

--- a/app/views/vendor_records/_form.html.erb
+++ b/app/views/vendor_records/_form.html.erb
@@ -7,7 +7,7 @@
           <% if vendor_record.errors.any? %>
             <div id="error_explanation">
               <% vendor_record.errors.full_messages.each do |message| %>
-                <%= alert_generator message, "error" %>
+                <%= form_error_alert(message) %>
               <% end %>
             </div>
           <% end %>

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,18 +1,15 @@
 # frozen_string_literal: true
 
 # Entry-point SCSS files compiled to app/assets/builds/ by dartsass-rails.
-# Bootstrap and gritter still come from gems until #16 (npm Bootstrap migration).
-# Gritter import rules live in app/assets/stylesheets/_gem_dependencies.scss.
+# Bootstrap still comes from the gem until #16 (npm Bootstrap migration).
 #
 # --quiet-deps and --silence-deprecation=import suppress Dart Sass @import warnings
 # (vendor + app SCSS). Remove when SCSS is migrated to @use/@forward (follow-up ticket).
-gritter_stylesheets = File.join(Gem.loaded_specs['gritter'].full_gem_path, 'app/assets/stylesheets')
 bootstrap_stylesheets = File.join(Gem.loaded_specs['bootstrap'].full_gem_path, 'assets/stylesheets')
 
 Rails.application.config.dartsass.build_options ||= []
 Rails.application.config.dartsass.build_options << '--quiet-deps'
 Rails.application.config.dartsass.build_options << '--silence-deprecation=import'
-Rails.application.config.dartsass.build_options << "--load-path=#{gritter_stylesheets}"
 Rails.application.config.dartsass.build_options << "--load-path=#{bootstrap_stylesheets}"
 
 Rails.application.config.dartsass.builds = {

--- a/spec/controllers/software_records_controller_spec.rb
+++ b/spec/controllers/software_records_controller_spec.rb
@@ -508,8 +508,8 @@ RSpec.describe SoftwareRecordsController, type: :controller do
         put :update, params: { id: software_record.to_param, software_record: invalid_attributes }, session: valid_session
         expect(response).to be_successful
         expect(response).to render_template(:edit)
-        expect(response.body).to have_content("Title can\\'t be blank")
-        expect(response.body).to have_content("Description can\\'t be blank")
+        expect(response.body).to have_content("Title can't be blank")
+        expect(response.body).to have_content("Description can't be blank")
       end
     end
   end
@@ -803,8 +803,8 @@ RSpec.describe SoftwareRecordsController, type: :controller do
         put :update, params: { id: software_record.to_param, software_record: invalid_attributes }, session: valid_session
         expect(response).to_not be_successful
         expect(response).to_not render_template(:edit)
-        expect(response.body).to_not have_content("Title can\\'t be blank")
-        expect(response.body).to_not have_content("Description can\\'t be blank")
+        expect(response.body).to_not have_content("Title can't be blank")
+        expect(response.body).to_not have_content("Description can't be blank")
       end
     end
   end
@@ -1117,8 +1117,8 @@ RSpec.describe SoftwareRecordsController, type: :controller do
         put :update, params: { id: software_record.to_param, software_record: invalid_attributes }, session: valid_session
         expect(response).to be_successful
         expect(response).to render_template(:edit)
-        expect(response.body).to have_content("Title can\\'t be blank")
-        expect(response.body).to have_content("Description can\\'t be blank")
+        expect(response.body).to have_content("Title can't be blank")
+        expect(response.body).to have_content("Description can't be blank")
       end
     end
   end
@@ -1431,8 +1431,8 @@ RSpec.describe SoftwareRecordsController, type: :controller do
         put :update, params: { id: software_record.to_param, software_record: invalid_attributes }, session: valid_session
         expect(response).to be_successful
         expect(response).to render_template(:edit)
-        expect(response.body).to have_content("Title can\\'t be blank")
-        expect(response.body).to have_content("Description can\\'t be blank")
+        expect(response.body).to have_content("Title can't be blank")
+        expect(response.body).to have_content("Description can't be blank")
       end
     end
   end

--- a/spec/controllers/software_types_controller_spec.rb
+++ b/spec/controllers/software_types_controller_spec.rb
@@ -156,8 +156,8 @@ RSpec.describe SoftwareTypesController, type: :controller do
                      session: valid_session
         expect(response).to be_successful
         expect(response).to render_template(:edit)
-        expect(response.body).to have_content("Title can\\'t be blank")
-        expect(response.body).to have_content("Description can\\'t be blank")
+        expect(response.body).to have_content("Title can't be blank")
+        expect(response.body).to have_content("Description can't be blank")
       end
     end
   end
@@ -310,8 +310,8 @@ RSpec.describe SoftwareTypesController, type: :controller do
                      session: valid_session
         expect(response).to be_successful
         expect(response).to render_template(:edit)
-        expect(response.body).to have_content("Title can\\'t be blank")
-        expect(response.body).to have_content("Description can\\'t be blank")
+        expect(response.body).to have_content("Title can't be blank")
+        expect(response.body).to have_content("Description can't be blank")
       end
     end
   end
@@ -464,8 +464,8 @@ RSpec.describe SoftwareTypesController, type: :controller do
                      session: valid_session
         expect(response).to be_successful
         expect(response).to render_template(:edit)
-        expect(response.body).to have_content("Title can\\'t be blank")
-        expect(response.body).to have_content("Description can\\'t be blank")
+        expect(response.body).to have_content("Title can't be blank")
+        expect(response.body).to have_content("Description can't be blank")
       end
     end
   end
@@ -618,8 +618,8 @@ RSpec.describe SoftwareTypesController, type: :controller do
                      session: valid_session
         expect(response).to_not be_successful
         expect(response).to_not render_template(:edit)
-        expect(response.body).to_not have_content("Title can\\'t be blank")
-        expect(response.body).to_not have_content("Description can\\'t be blank")
+        expect(response.body).to_not have_content("Title can't be blank")
+        expect(response.body).to_not have_content("Description can't be blank")
       end
     end
   end

--- a/spec/controllers/vendor_records_controller_spec.rb
+++ b/spec/controllers/vendor_records_controller_spec.rb
@@ -154,8 +154,8 @@ RSpec.describe VendorRecordsController, type: :controller do
                      session: valid_session
         expect(response).to be_successful
         expect(response).to render_template(:edit)
-        expect(response.body).to have_content("Title can\\'t be blank")
-        expect(response.body).to have_content("Description can\\'t be blank")
+        expect(response.body).to have_content("Title can't be blank")
+        expect(response.body).to have_content("Description can't be blank")
       end
     end
   end
@@ -306,8 +306,8 @@ RSpec.describe VendorRecordsController, type: :controller do
                      session: valid_session
         expect(response).to be_successful
         expect(response).to render_template(:edit)
-        expect(response.body).to have_content("Title can\\'t be blank")
-        expect(response.body).to have_content("Description can\\'t be blank")
+        expect(response.body).to have_content("Title can't be blank")
+        expect(response.body).to have_content("Description can't be blank")
       end
     end
   end
@@ -458,8 +458,8 @@ RSpec.describe VendorRecordsController, type: :controller do
                      session: valid_session
         expect(response).to be_successful
         expect(response).to render_template(:edit)
-        expect(response.body).to have_content("Title can\\'t be blank")
-        expect(response.body).to have_content("Description can\\'t be blank")
+        expect(response.body).to have_content("Title can't be blank")
+        expect(response.body).to have_content("Description can't be blank")
       end
     end
   end
@@ -610,8 +610,8 @@ RSpec.describe VendorRecordsController, type: :controller do
                      session: valid_session
         expect(response).to_not be_successful
         expect(response).to_not render_template(:edit)
-        expect(response.body).to_not have_content("Title can\\'t be blank")
-        expect(response.body).to_not have_content("Description can\\'t be blank")
+        expect(response.body).to_not have_content("Title can't be blank")
+        expect(response.body).to_not have_content("Description can't be blank")
       end
     end
   end

--- a/spec/features/file_uploads_spec.rb
+++ b/spec/features/file_uploads_spec.rb
@@ -28,6 +28,7 @@ RSpec.feature 'File uploads (seed import)', type: :feature do
     click_button 'Import Data'
 
     expect(page).to have_current_path(file_uploads_new_path)
+    expect(page.body).to include('flash-toast')
     expect(page.body).to include('has been loaded successfully')
     expect(Dir[upload_dir.join('*').to_s]).to be_empty
   end
@@ -42,6 +43,7 @@ RSpec.feature 'File uploads (seed import)', type: :feature do
     click_button 'Import Data'
 
     expect(page).to have_current_path(file_uploads_new_path)
+    expect(page.body).to include('flash-toast')
     expect(page.body).to include('has been loaded successfully')
     expect(File.exist?(upload_dir.join('unsaferecords.csv'))).to be(false)
   ensure

--- a/spec/helpers/flash_messages_helper_spec.rb
+++ b/spec/helpers/flash_messages_helper_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FlashMessagesHelper, type: :helper do
+  describe '#alerts' do
+    it 'renders nothing when flash is empty' do
+      alerts
+
+      expect(rendered).to be_blank
+    end
+
+    it 'renders a Bootstrap toast for notice' do
+      flash[:notice] = 'Status was successfully created.'
+      alerts
+
+      expect(rendered).to have_css('.flash-toast-container .toast', text: /Status was successfully created/)
+      expect(rendered).to have_css('.toast-header', text: FlashMessagesHelper::FLASH_APP_TITLE)
+      expect(rendered).to include('data-bs-delay="3000"')
+    end
+
+    it 'renders a Bootstrap toast for alert with allowed HTML' do
+      flash[:alert] = 'Permission denied.<br/>Contact the administrator.'
+      alerts
+
+      expect(rendered).to have_css('.toast-body br')
+      expect(rendered).to include('Permission denied.')
+    end
+
+    %w[success error warning].each do |type|
+      it "renders a Bootstrap toast for #{type}" do
+        flash[type.to_sym] = "#{type.capitalize} message."
+        alerts
+
+        expect(rendered).to have_css('.flash-toast', text: /#{type.capitalize} message/)
+      end
+    end
+
+    it 'renders each present flash type' do
+      flash[:notice] = 'Saved.'
+      flash[:error] = 'Failed.'
+      alerts
+
+      expect(rendered).to have_css('.flash-toast', count: 2)
+    end
+  end
+
+  describe '#form_error_alert' do
+    it 'renders a Bootstrap danger alert with sanitized HTML' do
+      alert = form_error_alert('Name cannot be blank.<br/>Try again.')
+
+      expect(alert).to include('alert alert-danger')
+      expect(alert).to include('Name cannot be blank.')
+      expect(alert).to include('<br>')
+    end
+  end
+end

--- a/spec/helpers/flash_messages_helper_spec.rb
+++ b/spec/helpers/flash_messages_helper_spec.rb
@@ -43,6 +43,29 @@ RSpec.describe FlashMessagesHelper, type: :helper do
 
       expect(rendered).to have_css('.flash-toast', count: 2)
     end
+
+    it 'renders type-specific toast icons' do
+      flash[:notice] = 'Saved.'
+      flash[:error] = 'Failed.'
+      alerts
+
+      expect(rendered).to have_css('.fa-info-circle.text-info')
+      expect(rendered).to have_css('.fa-times-circle.text-danger')
+    end
+  end
+
+  describe '#flash_message_body' do
+    it 'allows br tags in flash copy' do
+      expect(flash_message_body('Line one<br/>Line two')).to include('<br>')
+      expect(flash_message_body('Line one<br/>Line two')).to include('Line one')
+    end
+
+    it 'strips disallowed HTML tags' do
+      body = flash_message_body('<script>alert("x")</script>Safe text')
+
+      expect(body).not_to include('<script>')
+      expect(body).to include('Safe text')
+    end
   end
 
   describe '#form_error_alert' do

--- a/spec/requests/flash_messages_spec.rb
+++ b/spec/requests/flash_messages_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Flash messages in responses', type: :request do
+  let(:admin) { FactoryBot.create(:admin) }
+
+  before { sign_in admin }
+
+  it 'renders Bootstrap toast markup after a redirect with notice' do
+    status = FactoryBot.create(:status, title: 'Active', status_type: 'Design')
+
+    patch status_path(status), params: { status: { title: 'Updated', status_type: 'Design' } }
+
+    follow_redirect!
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('flash-toast-container')
+    expect(response.body).to include('data-bs-delay="3000"')
+    expect(response.body).to include('Status was successfully updated')
+    expect(response.body).not_to include('gritter')
+  end
+
+  it 'renders Bootstrap form error alerts for invalid submissions' do
+    status = FactoryBot.create(:status, title: 'Active', status_type: 'Design')
+
+    patch status_path(status), params: { status: { title: '', status_type: '' } }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('id="error_explanation"')
+    expect(response.body).to include('alert alert-danger')
+    expect(response.body).to include("Title can't be blank")
+    expect(response.body).not_to include('gritter')
+  end
+
+  it 'renders an error toast after a redirect with flash error' do
+    post file_uploads_path, params: { file_upload: { name: 'No file' }, seed: 'srecords' }
+
+    expect(response).to redirect_to(file_uploads_new_path)
+    follow_redirect!
+
+    expect(response.body).to include('flash-toast')
+    expect(response.body).to include('Cannot process seed data without input file.')
+  end
+end

--- a/spec/support/dartsass.rb
+++ b/spec/support/dartsass.rb
@@ -2,8 +2,7 @@
 
 # Tests need freshly compiled CSS from app/assets/builds/. A leftover
 # public/assets manifest from assets:precompile pins stale digests and can
-# make stylesheet_link_tag serve outdated CSS (e.g. a runtime gritter @import
-# that resolves to Rails HTML).
+# make stylesheet_link_tag serve outdated CSS from a previous assets:precompile run.
 RSpec.configure do |config|
   config.before(:suite) do
     public_assets = Rails.public_path.join('assets')

--- a/spec/views/shared/form_errors.html.erb_spec.rb
+++ b/spec/views/shared/form_errors.html.erb_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'shared/form_errors', type: :view do
+  let(:status) { Status.new(title: '', status_type: '') }
+
+  it 'renders nothing when the object has no errors' do
+    status.title = 'Valid'
+    status.status_type = 'Design'
+    status.validate
+
+    render partial: 'shared/form_errors', locals: { object: status }
+
+    expect(rendered).to be_blank
+  end
+
+  it 'renders Bootstrap danger alerts for each error message' do
+    status.validate
+
+    render partial: 'shared/form_errors', locals: { object: status }
+
+    expect(rendered).to have_css('#error_explanation .alert.alert-danger', minimum: 1)
+    expect(rendered).to include("Title can't be blank")
+  end
+end

--- a/spec/views/software_records/edit_road_map.html.erb_spec.rb
+++ b/spec/views/software_records/edit_road_map.html.erb_spec.rb
@@ -61,4 +61,13 @@ RSpec.describe 'software_records/edit_road_map', type: :view do
     expect(rendered).to have_button('Update')
     expect(rendered).to have_link('Back', href: software_records_path)
   end
+
+  it 'displays validation errors with Bootstrap alerts' do
+    @software_record.title = ''
+    @software_record.validate
+
+    render
+
+    expect(rendered).to have_css('#error_explanation .alert.alert-danger', text: /Title can't be blank/)
+  end
 end


### PR DESCRIPTION
## Summary

- Removes the unmaintained `gritter` gem and all gritter CSS/JS imports (Sprockets manifest, Dart Sass `_gem_dependencies`, dartsass initializer load path).
- Replaces redirect flash messages with Bootstrap 5 toasts (`FlashMessagesHelper`, `shared/_alerts`, `flash_toasts.js` on `turbo:load`).
- Replaces form validation gritter popups with inline Bootstrap danger alerts via `form_error_alert` and a shared `shared/_form_errors` partial (forms, Devise, road map edit).
- Adds request, helper, view, and feature spec coverage for toast markup and form error rendering.

## Test plan

- [x] `bundle exec rubocop`
- [x] `bundle exec rspec` (569 examples, 0 failures)
- [ ] On QA: create or update a record — success `notice` appears as a top-right toast and auto-dismisses
- [ ] On QA: submit an invalid form — red Bootstrap alerts appear inline above the form fields
- [ ] On QA: trigger an `alert` flash (e.g. empty search, permission denied with `<br/>`) — toast renders correctly
- [ ] On QA: failed seed import (no file) — error toast appears after redirect
- [ ] Confirm no gritter assets or JS errors in the browser console