### PR TITLE
Remove jquery-rails now that app JavaScript is jQuery-free.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,9 +59,8 @@ gem 'rubocop-rspec', require: false
 # Use simplecov to generate the coveralls report in .html format
 gem 'simplecov', require: false
 gem 'simplecov-lcov', require: false
-# Use bootstrap css, jquery-rails gem for styling the components
+# Use bootstrap for styling components
 gem 'bootstrap', '~> 5.3.3'
-gem 'jquery-rails'
 # Use dotenv gem to store the environment variables
 gem 'dotenv-rails'
 # Use petergate for authorization

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,10 +197,6 @@ GEM
     jbuilder (2.15.1)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
-    jquery-rails (4.6.1)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.19.9)
@@ -501,7 +497,6 @@ DEPENDENCIES
   globalize (~> 7.0)
   groupdate
   jbuilder (~> 2.5)
-  jquery-rails
   jsbundling-rails (~> 1.3)
   json (>= 2.10.2)
   listen (~> 3.5)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,7 +10,6 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery3
 //= require bootstrap
 //= require activestorage
 //= require chartkick

--- a/spec/build/assets_precompile_spec.rb
+++ b/spec/build/assets_precompile_spec.rb
@@ -2,11 +2,24 @@
 
 require 'rails_helper'
 
-RSpec.describe 'assets precompile' do
-  it 'does not auto-run javascript:build in test (deploy uses production env too)' do
-    Rails.application.load_tasks
+RSpec.describe 'assets pipeline' do
+  let(:sprockets_manifest) { Rails.root.join('app/assets/javascripts/application.js').read }
+  let(:gemfile_lock) { Rails.root.join('Gemfile.lock').read }
 
-    expect(Rake::Task['assets:precompile'].prerequisites).to include('dartsass:build')
-    expect(Rake::Task['assets:precompile'].prerequisites).not_to include('javascript:build')
+  it 'does not require jquery in the Sprockets manifest' do
+    expect(sprockets_manifest).not_to match(/require jquery/i)
+  end
+
+  it 'does not list jquery-rails in Gemfile.lock' do
+    expect(gemfile_lock).not_to include('jquery-rails')
+  end
+
+  describe 'assets:precompile task' do
+    it 'does not auto-run javascript:build in test (deploy uses production env too)' do
+      Rails.application.load_tasks
+
+      expect(Rake::Task['assets:precompile'].prerequisites).to include('dartsass:build')
+      expect(Rake::Task['assets:precompile'].prerequisites).not_to include('javascript:build')
+    end
   end
 end

--- a/spec/requests/turbo_layout_spec.rb
+++ b/spec/requests/turbo_layout_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe 'Turbo layout integration', type: :request do
     expect(turbo_position).to be_present
     expect(application_position).to be_present
     expect(turbo_position).to be < application_position
+    expect(script_sources).not_to include(a_string_matching(/jquery/i))
   end
 
   it 'renders software_records layout with data-turbo-track assets' do
@@ -31,5 +32,8 @@ RSpec.describe 'Turbo layout integration', type: :request do
     expect(response.body).to include('data-turbo-track="reload"')
     expect(response.body).to include('type="module"')
     expect(response.body).not_to include('data-turbolinks-track')
+
+    script_sources = response.body.scan(/<script[^>]+src="([^"]+)"/).flatten
+    expect(script_sources).not_to include(a_string_matching(/jquery/i))
   end
 end


### PR DESCRIPTION
Drop the gem and Sprockets manifest require; add pipeline and layout specs to guard against jQuery regressions.

## Summary

- Removes the `jquery-rails` gem and `//= require jquery3` from the Sprockets `application.js` manifest.
- Confirmed no `$()`, `jQuery`, or `jquery` usage remains in app views, helpers, or JavaScript (custom JS is already vanilla DOM; Bootstrap 5, Chartkick/Chart.js, and Turbo do not require jQuery).
- Extends asset pipeline and turbo layout specs to guard against jQuery regressions in the manifest, lockfile, and layout script tags.

## Test plan

- [x] `bundle exec rubocop`
- [x] `bundle exec rspec` (571 examples, 0 failures)
- [ ] On QA: load dashboard — pie/line charts render without console errors
- [ ] On QA: software record edit — Bootstrap tabs and multi-value add/remove work
- [ ] On QA: confirm no `jquery` in Network tab script requests