### PR TITLE
Libappo1 117 remove vestigial sprockets

### DIFF
--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -6,4 +6,4 @@
 Rails.application.config.assets.version = '1.0'
 
 # Compiled CSS/JS from dartsass-rails and esbuild live in app/assets/builds/.
-# Sprockets discovers them via app/assets/config/manifest.js until Propshaft (#19).
+# Sprockets discovers them via app/assets/config/manifest.js until the Propshaft migration.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -5,17 +5,5 @@
 # Version of your assets, change this if you want to expire all your assets.
 Rails.application.config.assets.version = '1.0'
 
-# Compiled CSS/JS from dartsass-rails and esbuild live in app/assets/builds/ (linked in manifest.js).
-Rails.application.config.assets.precompile += %w[software_records.css]
-
-# Sprockets 4 always registers a built-in CoffeeScript transformer, which lazily
-# requires the `coffee_script` library when resolving any JavaScript asset. Since
-# this app no longer depends on CoffeeScript, drop that transformer so precompile
-# does not fail loading a gem that is intentionally absent.
-Rails.application.config.assets.configure do |env|
-  coffee_free_transformers = env.config[:registered_transformers].reject do |transformer|
-    transformer.from == 'text/coffeescript' || transformer.to == 'text/coffeescript'
-  end
-  env.config = env.config.merge(registered_transformers: coffee_free_transformers).freeze
-  env.send(:compute_transformers!, coffee_free_transformers)
-end
+# Compiled CSS/JS from dartsass-rails and esbuild live in app/assets/builds/.
+# Sprockets discovers them via app/assets/config/manifest.js until Propshaft (#19).

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -4,11 +4,17 @@
 # Bootstrap SCSS is imported from app/assets/stylesheets/vendor/bootstrap/scss/
 # (vendored from npm; see lib/bootstrap_vendor.rb and README).
 #
-# --quiet-deps and --silence-deprecation=import suppress Dart Sass @import warnings
-# (vendor + app SCSS). Remove when SCSS is migrated to @use/@forward (follow-up ticket).
+# Bootstrap 5.3 SCSS still uses @import and legacy Sass APIs that Dart Sass deprecates.
+# --quiet-deps and --silence-deprecation keep build/test output readable until Bootstrap
+# migrates to @use/@forward and modern color/builtin APIs (or we change CSS strategy).
 Rails.application.config.dartsass.build_options ||= []
-Rails.application.config.dartsass.build_options << '--quiet-deps'
-Rails.application.config.dartsass.build_options << '--silence-deprecation=import'
+Rails.application.config.dartsass.build_options |= %w[
+  --quiet-deps
+  --silence-deprecation=import
+  --silence-deprecation=color-functions
+  --silence-deprecation=if-function
+  --silence-deprecation=global-builtin
+]
 
 Rails.application.config.dartsass.builds = {
   'application.scss' => 'application.css',

--- a/spec/build/assets_precompile_spec.rb
+++ b/spec/build/assets_precompile_spec.rb
@@ -16,9 +16,18 @@ RSpec.describe 'assets pipeline' do
     expect(gemfile_lock).not_to match(/^\s+bootstrap\s*\(/m)
   end
 
-  it 'does not link the legacy Sprockets javascripts directory in the asset manifest' do
+  it 'does not register vestigial Sprockets precompile paths or CoffeeScript workarounds' do
+    source = Rails.root.join('config/initializers/assets.rb').read
+
+    expect(source).not_to include('config.assets.precompile')
+    expect(source).not_to include('coffee_free_transformers')
+    expect(source).not_to include('node_modules')
+  end
+
+  it 'links builds and images via the Sprockets manifest until Propshaft' do
     expect(manifest).not_to include('link_directory ../javascripts')
     expect(manifest).to include('link_tree ../builds')
+    expect(manifest).to include('link_tree ../images')
   end
 
   it 'does not use Sprockets require directives in app javascript sources' do

--- a/spec/build/assets_precompile_spec.rb
+++ b/spec/build/assets_precompile_spec.rb
@@ -16,12 +16,22 @@ RSpec.describe 'assets pipeline' do
     expect(gemfile_lock).not_to match(/^\s+bootstrap\s*\(/m)
   end
 
-  it 'does not register vestigial Sprockets precompile paths or CoffeeScript workarounds' do
-    source = Rails.root.join('config/initializers/assets.rb').read
+  it 'sets the Sprockets assets version for cache busting' do
+    expect(Rails.application.config.assets.version).to eq('1.0')
+  end
 
-    expect(source).not_to include('config.assets.precompile')
-    expect(source).not_to include('coffee_free_transformers')
-    expect(source).not_to include('node_modules')
+  it 'does not register vestigial Sprockets precompile paths' do
+    precompile = Rails.application.config.assets.precompile.map(&:to_s)
+
+    expect(precompile).not_to include('software_records.css')
+    expect(precompile).not_to include(a_string_matching(/navigation\.js/))
+    expect(precompile).not_to include(a_string_matching(/filtermanagement\.js/))
+  end
+
+  it 'does not add node_modules to the Sprockets asset load path' do
+    paths = Rails.application.config.assets.paths.map(&:to_s)
+
+    expect(paths).not_to include(a_string_matching(%r{/node_modules\z}))
   end
 
   it 'links builds and images via the Sprockets manifest until Propshaft' do

--- a/spec/build/javascript_build_spec.rb
+++ b/spec/build/javascript_build_spec.rb
@@ -2,13 +2,9 @@
 
 require 'rails_helper'
 
-RSpec.describe 'esbuild javascript build', :build do
+RSpec.describe 'esbuild javascript build' do
   it 'javascript:build produces app/assets/builds/application.js' do
-    Rails.application.load_tasks
-    %w[javascript:prepare_node_path javascript:install javascript:build].each do |name|
-      Rake::Task[name].reenable
-    end
-    Rake::Task['javascript:build'].invoke
+    QuietTestBuilds.invoke_javascript_build!
 
     bundle = Rails.root.join('app/assets/builds/application.js')
     expect(bundle).to exist

--- a/spec/build/sprockets_precompile_spec.rb
+++ b/spec/build/sprockets_precompile_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'assets:precompile', :build do
+RSpec.describe 'assets:precompile' do
   let(:public_assets) { Rails.public_path.join('assets') }
 
   after do
@@ -10,17 +10,11 @@ RSpec.describe 'assets:precompile', :build do
   end
 
   it 'fingerprints dartsass and esbuild outputs without explicit precompile entries' do
-    FileUtils.rm_rf(public_assets)
+    QuietTestBuilds.precompile_assets!
 
-    Rails.application.load_tasks
-    Rake::Task['dartsass:build'].reenable
-    Rake::Task['dartsass:build'].invoke
-    Rake::Task['assets:precompile'].reenable
-    Rake::Task['assets:precompile'].invoke
-
-    compiled = Dir.children(public_assets)
-    expect(compiled.any? { |name| name.start_with?('.sprockets-manifest') }).to be(true)
-    expect(compiled.any? { |name| name.start_with?('application-') && name.end_with?('.js') }).to be(true)
-    expect(compiled.any? { |name| name.start_with?('software_records-') && name.end_with?('.css') }).to be(true)
+    expect(Dir.children(public_assets).any? { |name| name.start_with?('.sprockets-manifest') }).to be(true)
+    expect(CompiledAssetExpectations.fingerprinted_asset?(public_assets, 'application', '.js')).to be(true)
+    expect(CompiledAssetExpectations.fingerprinted_asset?(public_assets, 'application', '.css')).to be(true)
+    expect(CompiledAssetExpectations.fingerprinted_asset?(public_assets, 'software_records', '.css')).to be(true)
   end
 end

--- a/spec/build/sprockets_precompile_spec.rb
+++ b/spec/build/sprockets_precompile_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'assets:precompile', :build do
+  let(:public_assets) { Rails.public_path.join('assets') }
+
+  after do
+    FileUtils.rm_rf(public_assets)
+  end
+
+  it 'fingerprints dartsass and esbuild outputs without explicit precompile entries' do
+    FileUtils.rm_rf(public_assets)
+
+    Rails.application.load_tasks
+    Rake::Task['dartsass:build'].reenable
+    Rake::Task['dartsass:build'].invoke
+    Rake::Task['assets:precompile'].reenable
+    Rake::Task['assets:precompile'].invoke
+
+    compiled = Dir.children(public_assets)
+    expect(compiled.any? { |name| name.start_with?('.sprockets-manifest') }).to be(true)
+    expect(compiled.any? { |name| name.start_with?('application-') && name.end_with?('.js') }).to be(true)
+    expect(compiled.any? { |name| name.start_with?('software_records-') && name.end_with?('.css') }).to be(true)
+  end
+end

--- a/spec/compiled_asset_expectations_spec.rb
+++ b/spec/compiled_asset_expectations_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe CompiledAssetExpectations do
+  describe '.fingerprinted_asset?' do
+    it 'returns true when a matching fingerprinted file exists' do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, 'application-deadbeef.js'), 'x')
+
+        expect(described_class.fingerprinted_asset?(dir, 'application', '.js')).to be(true)
+      end
+    end
+
+    it 'returns false when only a different extension matches the prefix' do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, 'application-deadbeef.css'), 'x')
+
+        expect(described_class.fingerprinted_asset?(dir, 'application', '.js')).to be(false)
+      end
+    end
+
+    it 'returns false when no file shares the logical name prefix' do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, 'trix-deadbeef.js'), 'x')
+
+        expect(described_class.fingerprinted_asset?(dir, 'application', '.js')).to be(false)
+      end
+    end
+
+    it 'returns false when the directory is empty' do
+      Dir.mktmpdir do |dir|
+        expect(described_class.fingerprinted_asset?(dir, 'application', '.js')).to be(false)
+      end
+    end
+  end
+end

--- a/spec/support/asset_builds.rb
+++ b/spec/support/asset_builds.rb
@@ -8,9 +8,7 @@ RSpec.configure do |config|
     public_assets = Rails.public_path.join('assets')
     FileUtils.rm_rf(public_assets) if public_assets.directory?
 
-    Rails.application.load_tasks
-    Rake::Task['dartsass:build'].reenable
-    Rake::Task['dartsass:build'].invoke
+    QuietTestBuilds.invoke_dartsass_build!
 
     # Test and production deploy use the committed bundle (SKIP_JS_BUILD in config/application.rb).
     next if ENV['SKIP_JS_BUILD'] == 'true'
@@ -19,9 +17,6 @@ RSpec.configure do |config|
     js_sources = Rails.root.join('app/javascript/**/*.js')
     next unless EsbuildBundleExpectations.stale_sources?(js_bundle, js_sources)
 
-    %w[javascript:prepare_node_path javascript:install javascript:build].each do |name|
-      Rake::Task[name].reenable
-    end
-    Rake::Task['javascript:build'].invoke
+    QuietTestBuilds.invoke_javascript_build!
   end
 end

--- a/spec/support/build_specs.rb
+++ b/spec/support/build_specs.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-RSpec.configure do |config|
-  # Esbuild build specs shell out to yarn; skip locally for quieter runs, keep in CI.
-  config.filter_run_excluding :build unless ENV['CI']
-end

--- a/spec/support/compiled_asset_expectations.rb
+++ b/spec/support/compiled_asset_expectations.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module CompiledAssetExpectations
+  module_function
+
+  def fingerprinted_asset?(directory, prefix, extension)
+    unless File.directory?(directory)
+      raise ArgumentError, "missing compiled assets directory: #{directory}"
+    end
+
+    Dir.children(directory).any? do |name|
+      name.start_with?("#{prefix}-") && name.end_with?(extension)
+    end
+  end
+end

--- a/spec/support/compiled_asset_expectations.rb
+++ b/spec/support/compiled_asset_expectations.rb
@@ -4,9 +4,7 @@ module CompiledAssetExpectations
   module_function
 
   def fingerprinted_asset?(directory, prefix, extension)
-    unless File.directory?(directory)
-      raise ArgumentError, "missing compiled assets directory: #{directory}"
-    end
+    raise ArgumentError, "missing compiled assets directory: #{directory}" unless File.directory?(directory)
 
     Dir.children(directory).any? do |name|
       name.start_with?("#{prefix}-") && name.end_with?(extension)

--- a/spec/support/quiet_test_builds.rb
+++ b/spec/support/quiet_test_builds.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'logger'
+
+# Test-only helpers for dartsass, esbuild, and Sprockets precompile.
+#
+# suppress_output reopens stdout/stderr file descriptors so shell-outs (yarn, esbuild)
+# and Sprockets' rake logger stay quiet; assigning $stdout alone does not affect system().
+module QuietTestBuilds
+  PRECOMPILE_TASKS = %w[dartsass:build assets:precompile].freeze
+  JAVASCRIPT_BUILD_TASKS = %w[javascript:prepare_node_path javascript:install javascript:build].freeze
+
+  module_function
+
+  def suppress_output
+    node_options = ENV['NODE_OPTIONS']
+    ENV['NODE_OPTIONS'] = [node_options, '--no-deprecation'].compact.join(' ')
+
+    stdout = $stdout.dup
+    stderr = $stderr.dup
+    sink = File.open(File::NULL, 'w')
+    $stdout.reopen(sink)
+    $stderr.reopen(sink)
+    yield
+  ensure
+    $stdout.reopen(stdout)
+    $stderr.reopen(stderr)
+    stdout.close
+    stderr.close
+    sink&.close
+    if node_options.nil?
+      ENV.delete('NODE_OPTIONS')
+    else
+      ENV['NODE_OPTIONS'] = node_options
+    end
+  end
+
+  def invoke_dartsass_build!(app = Rails.application)
+    app.load_tasks
+    Rake::Task['dartsass:build'].reenable
+    Rake::Task['dartsass:build'].invoke
+  end
+
+  def invoke_javascript_build!(app = Rails.application)
+    app.load_tasks
+    JAVASCRIPT_BUILD_TASKS.each { |name| Rake::Task[name].reenable }
+    suppress_output { Rake::Task['javascript:build'].invoke }
+  end
+
+  def precompile_assets!(app = Rails.application)
+    app.load_tasks
+    PRECOMPILE_TASKS.each { |name| Rake::Task[name].reenable }
+    suppress_output { Rake::Task['assets:precompile'].invoke }
+  end
+end


### PR DESCRIPTION
## Summary

- Remove vestigial Sprockets configuration from `config/initializers/assets.rb`: explicit `software_records.css` precompile entry, CoffeeScript transformer workaround, and related comments. Compiled assets in `app/assets/builds/` continue to be discovered via `app/assets/config/manifest.js` until the Propshaft migration.
- Silence Bootstrap 5.3 / Dart Sass deprecation noise (`import`, `color-functions`, `if-function`, `global-builtin`) in `config/initializers/dartsass.rb` so `dartsass:build` and the test suite stay readable.
- Strengthen asset pipeline specs: assert runtime Sprockets config (version, precompile paths, load paths) and manifest contents instead of brittle initializer source checks.
- Add `assets:precompile` integration coverage proving `application.js`, `application.css`, and `software_records.css` fingerprint without explicit precompile entries.
- Run build integration specs in the default `bundle exec rspec` suite (remove CI-only `:build` filter) and add `QuietTestBuilds` helpers to keep yarn/esbuild/Sprockets output quiet during tests.

## Test plan

- [x] `bundle exec rubocop`
- [x] `bundle exec rspec` (634 examples, 0 failures)
- [ ] Deploy to QA and confirm `assets:precompile` succeeds and pages load with expected CSS/JS