### PR TITLE
Libappo1 118 wire asset builds into ci and

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,10 @@ jobs:
       - run: bundle exec rake db:schema:load
 
       - run:
+          name: Compile Dart Sass builds
+          command: bundle exec rails dartsass:build
+
+      - run:
           name: Rubocop
           command: |
             gem install rubocop

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,6 +61,9 @@ jobs:
       - name: Prepare DB
         run: bundle exec rails db:prepare RAILS_ENV=test
 
+      - name: Compile Dart Sass builds
+        run: bundle exec rails dartsass:build
+
       - name: Run tests
         env:
           CI: "true"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ bin/dev
 
 **CI:** `yarn install --frozen-lockfile`, `yarn build`, and `bundle exec rails dartsass:build` run before RSpec.
 
-**Deploy:** Capistrano’s `deploy:assets:precompile` (during `deploy:updated`) sources `scripts/check_node.sh` (nvm + `.nvmrc`, yarn via corepack when needed) in the same shell as `bundle exec rails assets:precompile`, which runs `javascript:build` (yarn) and `dartsass:build` before fingerprinting assets.
+**Deploy:** Capistrano’s `deploy:assets:precompile` (during `deploy:updated`) runs `scripts/assets_precompile.sh`, which sources `scripts/check_node.sh` (nvm + `.nvmrc`, yarn via corepack when needed) then `bundle exec rails assets:precompile` (`javascript:build` + `dartsass:build`).
 
 ### Bootstrap (npm + vendored assets)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Node.js 24.x (see `.nvmrc`; run `nvm install` in the project root)
 
 JavaScript is bundled with **esbuild** via `jsbundling-rails` (LIBAPPO1-101, LIBAPPO1-108). The entry point is `app/javascript/application.js`; `bin/rails javascript:build` (or `bin/yarn build`) writes `app/assets/builds/application.js` and source maps. Layouts load that bundle as a single deferred ES module (Turbo, Bootstrap, Chartkick, Active Storage, and app scripts).
 
-`app/assets/builds/application.js` is **committed** so QA/production `assets:precompile` works without Node until deploy hosts have Node (`SKIP_JS_BUILD` in `config/application.rb`). After changing JS dependencies or source files:
+`app/assets/builds/application.js` is **committed** so CI can verify the bundle matches sources (`yarn build` + git diff in CircleCI and GitHub Actions). The **test** environment skips esbuild during `assets:precompile` (`SKIP_JS_BUILD` in `config/application.rb`); **production deploy** runs `yarn install`, `yarn build`, and `dartsass:build` before Sprockets precompile.
+
+After changing JS dependencies or source files locally:
 
 ```bash
 nvm use
@@ -43,13 +45,15 @@ nvm use
 bin/dev
 ```
 
-**Deploy:** `assets:precompile` skips the esbuild step on deploy hosts without Node; the committed bundle is fingerprinted like other assets. A follow-up deploy ticket will add Node and remove `SKIP_JS_BUILD`.
+**CI:** `yarn install --frozen-lockfile`, `yarn build`, and `bundle exec rails dartsass:build` run before RSpec.
+
+**Deploy:** Capistrano runs `source scripts/check_node.sh` (nvm + `.nvmrc`, yarn via corepack when needed) in the same shell as `bundle exec rails assets:precompile`, which runs `javascript:build` (yarn) and `dartsass:build` before fingerprinting assets.
 
 ### Bootstrap (npm + vendored assets)
 
 Bootstrap **5.x** is installed from npm (`package.json`). Dart Sass compiles the committed vendor SCSS under `app/assets/stylesheets/vendor/bootstrap/scss/`. JavaScript comes from the esbuild bundle (`import` from `node_modules` at build time).
 
-Deploy hosts do not run `yarn` until Node is on deploy, so vendored Bootstrap SCSS and the committed JS bundle must stay in git. After upgrading Bootstrap in `package.json`, refresh vendor SCSS and rebuild JS:
+Deploy hosts do not run `yarn` for Bootstrap SCSS vendoring (use `bootstrap:vendor` locally). JavaScript is rebuilt on deploy via `assets:precompile`. After upgrading Bootstrap in `package.json`, refresh vendor SCSS and rebuild JS locally:
 
 ```bash
 nvm use
@@ -113,6 +117,7 @@ cap production deploy  # production (libapps)
 | Environment | Host | Ruby manager | Notes |
 |-------------|------|--------------|-------|
 | QA / production | libappstest, libapps | **rbenv** (user `apache`, `/home/apache/.rbenv`) | `scripts/check_ruby.sh` runs on deploy to install the version from `.ruby-version` when missing |
+| QA / production | libappstest, libapps | **nvm** (user `apache`) | `scripts/check_node.sh` is sourced during `assets:precompile` to install Node from `.nvmrc` when missing |
 | Local cap deploy | localhost | **RVM** (via `scripts/start_local.sh` only) | Optional dev workflow; Capistrano does not use the capistrano-rvm gem |
 
 Puma on QA/production is managed by systemd (`puma-appport.service`), not by Capistrano's Ruby plugin.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ cap production deploy  # production (libapps)
 | Environment | Host | Ruby manager | Notes |
 |-------------|------|--------------|-------|
 | QA / production | libappstest, libapps | **rbenv** (user `apache`, `/home/apache/.rbenv`) | `scripts/check_ruby.sh` runs on deploy to install the version from `.ruby-version` when missing |
-| QA / production | libappstest, libapps | **nvm** (user `apache`) | `scripts/check_node.sh` is sourced during `deploy:assets:precompile` to install Node from `.nvmrc` when missing |
+| QA / production | libappstest, libapps | **nvm** (user `apache`) | `scripts/assets_precompile.sh` sources `check_node.sh` during `deploy:assets:precompile` |
 | Local cap deploy | localhost | **RVM** (via `scripts/start_local.sh` only) | Optional dev workflow; Capistrano does not use the capistrano-rvm gem |
 
 Puma on QA/production is managed by systemd (`puma-appport.service`), not by Capistrano's Ruby plugin.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ bin/dev
 
 **CI:** `yarn install --frozen-lockfile`, `yarn build`, and `bundle exec rails dartsass:build` run before RSpec.
 
-**Deploy:** Capistrano runs `source scripts/check_node.sh` (nvm + `.nvmrc`, yarn via corepack when needed) in the same shell as `bundle exec rails assets:precompile`, which runs `javascript:build` (yarn) and `dartsass:build` before fingerprinting assets.
+**Deploy:** Capistrano’s `deploy:assets:precompile` (during `deploy:updated`) sources `scripts/check_node.sh` (nvm + `.nvmrc`, yarn via corepack when needed) in the same shell as `bundle exec rails assets:precompile`, which runs `javascript:build` (yarn) and `dartsass:build` before fingerprinting assets.
 
 ### Bootstrap (npm + vendored assets)
 
@@ -117,7 +117,7 @@ cap production deploy  # production (libapps)
 | Environment | Host | Ruby manager | Notes |
 |-------------|------|--------------|-------|
 | QA / production | libappstest, libapps | **rbenv** (user `apache`, `/home/apache/.rbenv`) | `scripts/check_ruby.sh` runs on deploy to install the version from `.ruby-version` when missing |
-| QA / production | libappstest, libapps | **nvm** (user `apache`) | `scripts/check_node.sh` is sourced during `assets:precompile` to install Node from `.nvmrc` when missing |
+| QA / production | libappstest, libapps | **nvm** (user `apache`) | `scripts/check_node.sh` is sourced during `deploy:assets:precompile` to install Node from `.nvmrc` when missing |
 | Local cap deploy | localhost | **RVM** (via `scripts/start_local.sh` only) | Optional dev workflow; Capistrano does not use the capistrano-rvm gem |
 
 Puma on QA/production is managed by systemd (`puma-appport.service`), not by Capistrano's Ruby plugin.

--- a/bin/setup
+++ b/bin/setup
@@ -19,9 +19,10 @@ chdir APP_ROOT do
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 
-  # Install JavaScript dependencies if using Yarn
+  # Install JavaScript dependencies and compile asset builds.
   system!('bin/yarn install --frozen-lockfile')
   system!('bin/rails javascript:build')
+  system!('bin/rails dartsass:build')
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')

--- a/bin/update
+++ b/bin/update
@@ -19,8 +19,10 @@ chdir APP_ROOT do
   system! 'gem install bundler --conservative'
   system('bundle check') || system!('bundle install')
 
-  # Install JavaScript dependencies if using Yarn
-  # system('bin/yarn')
+  # Install JavaScript dependencies and rebuild asset builds after gem updates.
+  system!('bin/yarn install --frozen-lockfile')
+  system!('bin/rails javascript:build')
+  system!('bin/rails dartsass:build')
 
   puts "\n== Updating database =="
   system! 'bin/rails db:migrate'

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,8 +12,8 @@ Bundler.require(*Rails.groups)
 Dotenv::Rails.load
 
 # jsbundling-rails reads SKIP_JS_BUILD when rake tasks load (before initializers).
-# Deploy hosts lack Node 24 until Node is installed on deploy; committed app/assets/builds/application.js is used instead.
-ENV['SKIP_JS_BUILD'] = 'true' if %w[production test].include?(ENV['RAILS_ENV'])
+# Test uses the committed JS bundle (CI verifies freshness); production deploy builds via assets:precompile.
+ENV['SKIP_JS_BUILD'] = 'true' if ENV['RAILS_ENV'] == 'test'
 
 module ApplicationPortfolio
   class Application < Rails::Application

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -86,4 +86,6 @@ Capistrano::DSL.stages.each do |stage|
 end
 
 after 'deploy:publishing', 'db:migrate'
+# assets:precompile sources scripts/check_node.sh (nvm + yarn) then runs dartsass:build and
+# javascript:build (yarn install + yarn build) before fingerprinting assets.
 after 'deploy:publishing', 'assets:precompile'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -86,6 +86,5 @@ Capistrano::DSL.stages.each do |stage|
 end
 
 after 'deploy:publishing', 'db:migrate'
-# assets:precompile sources scripts/check_node.sh (nvm + yarn) then runs dartsass:build and
-# javascript:build (yarn install + yarn build) before fingerprinting assets.
-after 'deploy:publishing', 'assets:precompile'
+# deploy:assets:precompile (capistrano-rails, during deploy:updated) is overridden in
+# lib/capistrano/tasks/assets.rake to source scripts/check_node.sh before precompile.

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -87,4 +87,4 @@ end
 
 after 'deploy:publishing', 'db:migrate'
 # deploy:assets:precompile (capistrano-rails, during deploy:updated) is overridden in
-# lib/capistrano/tasks/assets.rake to source scripts/check_node.sh before precompile.
+# lib/capistrano/tasks/assets.rake to run scripts/assets_precompile.sh.

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -1,13 +1,19 @@
 # frozen_string_literal: true
 
-namespace :assets do
-  desc 'Compile dartsass + esbuild outputs and fingerprint assets for production'
-  task :precompile do
-    on roles(:db) do
-      within release_path do
-        with rails_env: fetch(:rails_env) do
-          execute :chmod, 'a+x', 'scripts/check_node.sh'
-          execute :bash, '-lc', 'source scripts/check_node.sh && bundle exec rails assets:precompile'
+# capistrano-rails runs deploy:assets:precompile during deploy:updated. Override it so
+# nvm Node from .nvmrc is on PATH before javascript:install (yarn checks engines.node).
+Rake::Task['deploy:assets:precompile'].clear_actions
+
+namespace :deploy do
+  namespace :assets do
+    desc 'Compile dartsass + esbuild outputs and fingerprint assets for production'
+    task :precompile do
+      on release_roles(fetch(:assets_roles)) do
+        within release_path do
+          with rails_env: fetch(:rails_env), rails_groups: fetch(:rails_assets_groups) do
+            execute :chmod, 'a+x', 'scripts/check_node.sh'
+            execute :bash, '-lc', 'source scripts/check_node.sh && bundle exec rails assets:precompile'
+          end
         end
       end
     end

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 namespace :assets do
-  desc 'Run assets precompile'
+  desc 'Compile dartsass + esbuild outputs and fingerprint assets for production'
   task :precompile do
     on roles(:db) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          execute :bundle, 'exec rails assets:precompile'
+          execute :chmod, 'a+x', 'scripts/check_node.sh'
+          execute :bash, '-lc', 'source scripts/check_node.sh && bundle exec rails assets:precompile'
         end
       end
     end

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -11,9 +11,9 @@ namespace :deploy do
       on release_roles(fetch(:assets_roles)) do
         within release_path do
           with rails_env: fetch(:rails_env), rails_groups: fetch(:rails_assets_groups) do
-            execute :chmod, 'a+x', 'scripts/check_node.sh'
-            # Single-string execute so SSHKit runs one shell command (multi-arg breaks && and -c).
-            execute 'source scripts/check_node.sh && bundle exec rails assets:precompile'
+            # Array-form execute (no spaces in command) so SSHKit applies cd + RAILS_ENV.
+            # scripts/assets_precompile.sh sources check_node.sh in the same shell.
+            execute :bash, 'scripts/assets_precompile.sh'
           end
         end
       end

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -11,8 +11,7 @@ namespace :deploy do
       on release_roles(fetch(:assets_roles)) do
         within release_path do
           with rails_env: fetch(:rails_env), rails_groups: fetch(:rails_assets_groups) do
-            # Array-form execute (no spaces in command) so SSHKit applies cd + RAILS_ENV.
-            # scripts/assets_precompile.sh sources check_node.sh in the same shell.
+            # Array-form execute so SSHKit applies within release_path and RAILS_ENV.
             execute :bash, 'scripts/assets_precompile.sh'
           end
         end

--- a/lib/capistrano/tasks/assets.rake
+++ b/lib/capistrano/tasks/assets.rake
@@ -12,7 +12,8 @@ namespace :deploy do
         within release_path do
           with rails_env: fetch(:rails_env), rails_groups: fetch(:rails_assets_groups) do
             execute :chmod, 'a+x', 'scripts/check_node.sh'
-            execute :bash, '-lc', 'source scripts/check_node.sh && bundle exec rails assets:precompile'
+            # Single-string execute so SSHKit runs one shell command (multi-arg breaks && and -c).
+            execute 'source scripts/check_node.sh && bundle exec rails assets:precompile'
           end
         end
       end

--- a/lib/tasks/javascript_build.rake
+++ b/lib/tasks/javascript_build.rake
@@ -6,8 +6,5 @@ namespace :javascript do
   end
 end
 
-%w[javascript:install javascript:build].each do |name|
-  next unless Rake::Task.task_defined?(name)
-
-  Rake::Task[name].enhance(['javascript:prepare_node_path'])
-end
+# Prepare PATH before yarn install; javascript:build already depends on install.
+Rake::Task['javascript:install'].enhance(['javascript:prepare_node_path']) if Rake::Task.task_defined?('javascript:install')

--- a/scripts/assets_precompile.sh
+++ b/scripts/assets_precompile.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Run on deploy via Capistrano (execute :bash, 'scripts/assets_precompile.sh') so SSHKit
+# applies within release_path and RAILS_ENV. Sources check_node.sh then precompiles assets.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+source scripts/check_node.sh
+exec bundle exec rails assets:precompile

--- a/scripts/assets_precompile.sh
+++ b/scripts/assets_precompile.sh
@@ -3,6 +3,10 @@
 # applies within release_path and RAILS_ENV. Sources check_node.sh then precompiles assets.
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+APP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$APP_ROOT"
+
+[ -f Gemfile ] || { echo "Not in application root: ${APP_ROOT}" >&2; exit 1; }
+
 source scripts/check_node.sh
 exec bundle exec rails assets:precompile

--- a/scripts/check_node.sh
+++ b/scripts/check_node.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# QA and production deploy hosts use nvm (user apache). Sourced during cap deploy
+# assets:precompile (see lib/capistrano/tasks/assets.rake) so nvm PATH persists
+# for yarn/esbuild. Installs the version from .nvmrc when missing.
+set -euo pipefail
+
+_sourced=0
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  _sourced=1
+fi
+
+_fail() {
+  echo "$1" >&2
+  if [[ $_sourced -eq 1 ]]; then
+    return 1
+  fi
+  exit 1
+}
+
+NODE_VERSION=$(tr -d 'v' < .nvmrc)
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+
+if [ ! -s "$NVM_DIR/nvm.sh" ]; then
+  _fail "nvm not found at $NVM_DIR/nvm.sh; install Node ${NODE_VERSION} before deploying"
+fi
+
+# shellcheck source=/dev/null
+. "$NVM_DIR/nvm.sh"
+
+if ! nvm which "$NODE_VERSION" >/dev/null 2>&1; then
+  nvm install "$NODE_VERSION" --no-progress
+fi
+
+nvm use "$NODE_VERSION"
+NODE_BIN="$(dirname "$(nvm which "$NODE_VERSION")")"
+export PATH="${NODE_BIN}:${PATH}"
+
+if ! command -v yarn >/dev/null 2>&1; then
+  if command -v corepack >/dev/null 2>&1; then
+    corepack enable
+  fi
+fi
+
+if ! command -v yarn >/dev/null 2>&1; then
+  _fail "yarn not found after activating Node ${NODE_VERSION}; install yarn or enable corepack on deploy hosts"
+fi
+
+if [[ $_sourced -eq 0 ]]; then
+  node -v
+  yarn -v
+fi

--- a/scripts/check_node.sh
+++ b/scripts/check_node.sh
@@ -1,27 +1,35 @@
-#!/bin/bash
-# QA and production deploy hosts use nvm (user apache). Sourced during cap deploy
-# assets:precompile (see lib/capistrano/tasks/assets.rake) so nvm PATH persists
-# for yarn/esbuild. Installs the version from .nvmrc when missing.
+#!/usr/bin/env bash
+# QA and production deploy hosts use nvm (user apache). Sourced from
+# scripts/assets_precompile.sh on deploy. Installs Node from .nvmrc when missing.
 set -euo pipefail
 
-_sourced=0
-if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
-  _sourced=1
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "Source this script: source scripts/check_node.sh" >&2
+  exit 1
 fi
 
-_fail() {
+die() {
   echo "$1" >&2
-  if [[ $_sourced -eq 1 ]]; then
-    return 1
-  fi
-  exit 1
+  return 1
 }
 
-NODE_VERSION=$(tr -d 'v' < .nvmrc)
+if [ ! -s .nvmrc ]; then
+  die ".nvmrc missing or empty; run from the application root"
+fi
+
+read -r NODE_VERSION_RAW < .nvmrc
+NODE_VERSION=${NODE_VERSION_RAW#v}
+NODE_VERSION=${NODE_VERSION//$'\r'/}
+NODE_VERSION=${NODE_VERSION//$'\n'/}
+
+if [ -z "$NODE_VERSION" ]; then
+  die ".nvmrc does not contain a Node version"
+fi
+
 export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 
 if [ ! -s "$NVM_DIR/nvm.sh" ]; then
-  _fail "nvm not found at $NVM_DIR/nvm.sh; install Node ${NODE_VERSION} before deploying"
+  die "nvm not found at $NVM_DIR/nvm.sh; install Node ${NODE_VERSION} before deploying"
 fi
 
 # shellcheck source=/dev/null
@@ -31,21 +39,19 @@ if ! nvm which "$NODE_VERSION" >/dev/null 2>&1; then
   nvm install "$NODE_VERSION" --no-progress
 fi
 
-nvm use "$NODE_VERSION"
+nvm use "$NODE_VERSION" >/dev/null
 NODE_BIN="$(dirname "$(nvm which "$NODE_VERSION")")"
 export PATH="${NODE_BIN}:${PATH}"
 
-if ! command -v yarn >/dev/null 2>&1; then
-  if command -v corepack >/dev/null 2>&1; then
-    corepack enable
-  fi
+ACTIVE_NODE="$(node -p "process.versions.node")"
+if [[ "$ACTIVE_NODE" != "$NODE_VERSION"* ]]; then
+  die "Active Node ${ACTIVE_NODE} does not match .nvmrc (${NODE_VERSION})"
+fi
+
+if ! command -v yarn >/dev/null 2>&1 && command -v corepack >/dev/null 2>&1; then
+  corepack enable
 fi
 
 if ! command -v yarn >/dev/null 2>&1; then
-  _fail "yarn not found after activating Node ${NODE_VERSION}; install yarn or enable corepack on deploy hosts"
-fi
-
-if [[ $_sourced -eq 0 ]]; then
-  node -v
-  yarn -v
+  die "yarn not found after activating Node ${NODE_VERSION}; install yarn or enable corepack on deploy hosts"
 fi

--- a/spec/build/assets_precompile_spec.rb
+++ b/spec/build/assets_precompile_spec.rb
@@ -83,8 +83,15 @@ RSpec.describe 'assets pipeline' do
   end
 
   describe 'assets:precompile task' do
-    it 'skips javascript:build in test (CI verifies the committed bundle; deploy builds on the server)' do
+    it 'sets SKIP_JS_BUILD in test so CI uses the committed bundle' do
+      expect(ENV['SKIP_JS_BUILD']).to eq('true')
+    end
+
+    it 'skips javascript:build in test (deploy builds on the server)' do
       Rails.application.load_tasks
+
+      install_prereqs = Rake::Task['javascript:install'].prerequisites
+      expect(install_prereqs).to include('javascript:prepare_node_path')
 
       expect(Rake::Task['assets:precompile'].prerequisites).to include('dartsass:build')
       expect(Rake::Task['assets:precompile'].prerequisites).not_to include('javascript:build')

--- a/spec/build/assets_precompile_spec.rb
+++ b/spec/build/assets_precompile_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'assets pipeline' do
   end
 
   describe 'assets:precompile task' do
-    it 'does not auto-run javascript:build in test (deploy uses committed bundle until Node is on deploy hosts)' do
+    it 'skips javascript:build in test (CI verifies the committed bundle; deploy builds on the server)' do
       Rails.application.load_tasks
 
       expect(Rake::Task['assets:precompile'].prerequisites).to include('dartsass:build')

--- a/spec/lib/capistrano_assets_spec.rb
+++ b/spec/lib/capistrano_assets_spec.rb
@@ -4,13 +4,19 @@ require 'rails_helper'
 
 RSpec.describe 'Capistrano asset deploy tasks' do
   let(:assets_rake) { Rails.root.join('lib/capistrano/tasks/assets.rake').read }
+  let(:assets_precompile_sh) { Rails.root.join('scripts/assets_precompile.sh').read }
   let(:check_node_sh) { Rails.root.join('scripts/check_node.sh').read }
 
-  it 'overrides capistrano-rails deploy:assets:precompile with check_node sourcing' do
+  it 'overrides capistrano-rails deploy:assets:precompile with a bash wrapper script' do
     expect(assets_rake).to include("Rake::Task['deploy:assets:precompile'].clear_actions")
-    expect(assets_rake).to include('namespace :deploy do')
-    expect(assets_rake).to include("execute 'source scripts/check_node.sh && bundle exec rails assets:precompile'")
+    expect(assets_rake).to include('within release_path')
+    expect(assets_rake).to include("execute :bash, 'scripts/assets_precompile.sh'")
     expect(assets_rake).to include('release_roles(fetch(:assets_roles))')
+  end
+
+  it 'sources check_node.sh from the deploy wrapper script' do
+    expect(assets_precompile_sh).to include('source scripts/check_node.sh')
+    expect(assets_precompile_sh).to include('bundle exec rails assets:precompile')
   end
 
   it 'detects installed Node via nvm which and exports PATH for yarn' do

--- a/spec/lib/capistrano_assets_spec.rb
+++ b/spec/lib/capistrano_assets_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Capistrano asset deploy tasks' do
+  let(:assets_rake) { Rails.root.join('lib/capistrano/tasks/assets.rake').read }
+  let(:check_node_sh) { Rails.root.join('scripts/check_node.sh').read }
+
+  it 'sources check_node.sh in the same shell as assets:precompile' do
+    expect(assets_rake).to include('source scripts/check_node.sh')
+    expect(assets_rake).to include('bundle exec rails assets:precompile')
+  end
+
+  it 'detects installed Node via nvm which and exports PATH for yarn' do
+    expect(check_node_sh).to include('.nvmrc')
+    expect(check_node_sh).to include('nvm which')
+    expect(check_node_sh).to include('export PATH')
+    expect(check_node_sh).to include('command -v yarn')
+  end
+end

--- a/spec/lib/capistrano_assets_spec.rb
+++ b/spec/lib/capistrano_assets_spec.rb
@@ -6,9 +6,12 @@ RSpec.describe 'Capistrano asset deploy tasks' do
   let(:assets_rake) { Rails.root.join('lib/capistrano/tasks/assets.rake').read }
   let(:check_node_sh) { Rails.root.join('scripts/check_node.sh').read }
 
-  it 'sources check_node.sh in the same shell as assets:precompile' do
+  it 'overrides capistrano-rails deploy:assets:precompile with check_node sourcing' do
+    expect(assets_rake).to include("Rake::Task['deploy:assets:precompile'].clear_actions")
+    expect(assets_rake).to include('namespace :deploy do')
     expect(assets_rake).to include('source scripts/check_node.sh')
     expect(assets_rake).to include('bundle exec rails assets:precompile')
+    expect(assets_rake).to include('release_roles(fetch(:assets_roles))')
   end
 
   it 'detects installed Node via nvm which and exports PATH for yarn' do

--- a/spec/lib/capistrano_assets_spec.rb
+++ b/spec/lib/capistrano_assets_spec.rb
@@ -7,21 +7,21 @@ RSpec.describe 'Capistrano asset deploy tasks' do
   let(:assets_precompile_sh) { Rails.root.join('scripts/assets_precompile.sh').read }
   let(:check_node_sh) { Rails.root.join('scripts/check_node.sh').read }
 
-  it 'overrides capistrano-rails deploy:assets:precompile with a bash wrapper script' do
+  it 'overrides deploy:assets:precompile to run the wrapper script with SSHKit cd/env' do
     expect(assets_rake).to include("Rake::Task['deploy:assets:precompile'].clear_actions")
     expect(assets_rake).to include('within release_path')
     expect(assets_rake).to include("execute :bash, 'scripts/assets_precompile.sh'")
     expect(assets_rake).to include('release_roles(fetch(:assets_roles))')
-  end
-
-  it 'sources check_node.sh from the deploy wrapper script' do
     expect(assets_precompile_sh).to include('source scripts/check_node.sh')
     expect(assets_precompile_sh).to include('bundle exec rails assets:precompile')
+    expect(assets_precompile_sh).to include('[ -f Gemfile ]')
   end
 
-  it 'detects installed Node via nvm which and exports PATH for yarn' do
-    expect(check_node_sh).to include('.nvmrc')
+  it 'requires check_node.sh to be sourced and activates nvm Node for yarn' do
+    expect(check_node_sh).to include('Source this script: source scripts/check_node.sh')
+    expect(check_node_sh).to include('.nvmrc missing or empty')
     expect(check_node_sh).to include('nvm which')
+    expect(check_node_sh).to include('process.versions.node')
     expect(check_node_sh).to include('export PATH')
     expect(check_node_sh).to include('command -v yarn')
   end

--- a/spec/lib/capistrano_assets_spec.rb
+++ b/spec/lib/capistrano_assets_spec.rb
@@ -9,8 +9,7 @@ RSpec.describe 'Capistrano asset deploy tasks' do
   it 'overrides capistrano-rails deploy:assets:precompile with check_node sourcing' do
     expect(assets_rake).to include("Rake::Task['deploy:assets:precompile'].clear_actions")
     expect(assets_rake).to include('namespace :deploy do')
-    expect(assets_rake).to include('source scripts/check_node.sh')
-    expect(assets_rake).to include('bundle exec rails assets:precompile')
+    expect(assets_rake).to include("execute 'source scripts/check_node.sh && bundle exec rails assets:precompile'")
     expect(assets_rake).to include('release_roles(fetch(:assets_roles))')
   end
 

--- a/spec/lib/javascript_build_env_spec.rb
+++ b/spec/lib/javascript_build_env_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe JavascriptBuildEnv do
+  describe '.nvm_node_bin' do
+    let(:root) { Pathname.new(Dir.mktmpdir) }
+
+    after { FileUtils.rm_rf(root) }
+
+    it 'returns nil when .nvmrc is missing' do
+      expect(described_class.nvm_node_bin(root)).to be_nil
+    end
+
+    it 'returns the nvm bin path when the version directory exists' do
+      root.join('.nvmrc').write("24.16.0\n")
+      nvm_dir = root.join('.nvm')
+      node_bin = nvm_dir.join('versions/node/v24.16.0/bin')
+      node_bin.mkpath
+
+      original_nvm_dir = ENV.fetch('NVM_DIR', nil)
+      ENV['NVM_DIR'] = nvm_dir.to_s
+      expect(described_class.nvm_node_bin(root)).to eq(node_bin.to_s)
+    ensure
+      ENV['NVM_DIR'] = original_nvm_dir
+    end
+
+    it 'strips a leading v from .nvmrc' do
+      root.join('.nvmrc').write("v24.16.0\n")
+      nvm_dir = root.join('.nvm')
+      node_bin = nvm_dir.join('versions/node/v24.16.0/bin')
+      node_bin.mkpath
+
+      original_nvm_dir = ENV.fetch('NVM_DIR', nil)
+      ENV['NVM_DIR'] = nvm_dir.to_s
+      expect(described_class.nvm_node_bin(root)).to eq(node_bin.to_s)
+    ensure
+      ENV['NVM_DIR'] = original_nvm_dir
+    end
+  end
+
+  describe '.apply!' do
+    it 'prepends the nvm Node bin directory to PATH' do
+      root = Pathname.new(Dir.mktmpdir)
+      root.join('.nvmrc').write("24.16.0\n")
+      nvm_dir = root.join('.nvm')
+      node_bin = nvm_dir.join('versions/node/v24.16.0/bin')
+      node_bin.mkpath
+
+      original_nvm_dir = ENV.fetch('NVM_DIR', nil)
+      original_path = ENV.fetch('PATH', nil)
+      ENV['NVM_DIR'] = nvm_dir.to_s
+      ENV['PATH'] = '/usr/bin'
+
+      described_class.apply!(root)
+
+      expect(ENV['PATH']).to start_with("#{node_bin}:")
+    ensure
+      ENV['NVM_DIR'] = original_nvm_dir
+      ENV['PATH'] = original_path
+      FileUtils.rm_rf(root)
+    end
+  end
+end

--- a/spec/support/asset_builds.rb
+++ b/spec/support/asset_builds.rb
@@ -10,7 +10,7 @@ RSpec.configure do |config|
 
     QuietTestBuilds.invoke_dartsass_build!
 
-    # Test and production deploy use the committed bundle (SKIP_JS_BUILD in config/application.rb).
+    # Test uses the committed bundle (SKIP_JS_BUILD); production deploy builds via assets:precompile.
     next if ENV['SKIP_JS_BUILD'] == 'true'
 
     js_bundle = Rails.root.join('app/assets/builds/application.js')


### PR DESCRIPTION
## Summary

- Wire **dartsass** and **esbuild** into CI and Capistrano deploy so QA/production run full `assets:precompile` (yarn install, yarn build, dartsass, Sprockets fingerprinting).
- Limit `SKIP_JS_BUILD` to **test** only; CI continues to verify the committed `application.js` bundle via `yarn build` + git diff.
- Add deploy scripts for Node 24 on nvm hosts: `scripts/check_node.sh` (nvm + `.nvmrc`) and `scripts/assets_precompile.sh` (Capistrano entry point).
- Override capistrano-rails `deploy:assets:precompile` to run `bash scripts/assets_precompile.sh` using array-form SSHKit execute (so `within release_path` and `RAILS_ENV` apply correctly).
- Update `bin/setup` / `bin/update` to rebuild JS and Dart Sass after dependency changes.

## Deploy flow

1. `deploy:updated` → capistrano-rails `deploy:assets:precompile` (overridden)
2. `bash scripts/assets_precompile.sh` (SSHKit array execute from `release_path` with `RAILS_ENV=production`)
3. `source scripts/check_node.sh` — install/activate Node from `.nvmrc` via nvm, export PATH, enable corepack/yarn if needed
4. `bundle exec rails assets:precompile` — `javascript:build` + `dartsass:build` + Sprockets

## Test plan

- [x] `bundle exec rubocop`
- [x] `bundle exec rspec` (641 examples)
- [x] Capistrano deploy to QA (`libappstest`) — Node 24 installed via nvm, yarn install/build succeeded, deploy completed
- [ ] Merge to `qa` and confirm CircleCI / GitHub Actions pass
- [ ] Production deploy after QA soak (first deploy may download Node 24 via nvm; subsequent deploys reuse it)