### PR TITLE
Libappo1 119 post-Propshaft verification and README updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,63 +3,91 @@
 # Application Portfolio
 
 This is a web application developed for the management of UC Libraries application profile.  
-This application tracks, monitors, and secures information on all of UCL's services, software, and support.  
-Provided that you have Ruby on Rails installed you can run this application on your local machine or server.
+This application tracks, monitors, and secures information on all of UCL's services, software, and support.
+
+### Quick start
 
 ```bash
 git clone git@github.com:uclibs/application_portfolio.git
 cd application_portfolio
+nvm install    # Node 24.x per .nvmrc
+nvm use
+bin/setup      # bundle, yarn, JS/CSS builds, db:setup
+bin/dev        # Rails + esbuild watch + dartsass watch (recommended)
+```
+
+Or run the server only after setup: `bin/rails server`.
+
+Use Ruby **3.4.9** (see `.ruby-version`), **Rails 8.1**, and **Node.js 24.x** (see `.nvmrc`). Local developers may use **RVM or rbenv**; deploy hosts use rbenv (see Deployment below).
+
+After pulling changes: `bin/update` (bundle, yarn, rebuild assets, migrate).
+
+## System dependencies
+
+| Requirement | Version / notes |
+|-------------|-----------------|
+| Ruby | 3.4.9 (`.ruby-version`) |
+| Rails | 8.1 |
+| Node.js | 24.x (`.nvmrc`; `nvm install` in project root) |
+| Yarn | 1.22.x via Corepack (`packageManager` in `package.json`) |
+
+## Asset pipeline
+
+Front-end assets use a **compile-then-serve** model (dartsass + esbuild → `app/assets/builds/`, Propshaft → `public/assets/`).
+
+```
+SCSS (app/assets/stylesheets/)  →  dartsass:build  →  app/assets/builds/*.css
+JS   (app/javascript/)          →  javascript:build →  app/assets/builds/application.js
+builds/ + images/               →  assets:precompile →  public/assets/ (+ .manifest.json)
+```
+
+**Propshaft** serves digest-stamped files from `public/assets/`. Layouts still use `stylesheet_link_tag` and `javascript_include_tag`; Propshaft resolves logical names (`application.css`, `application.js`) via the manifest. Source SCSS under `app/assets/stylesheets/` is excluded from Propshaft load paths (only compiled CSS in `builds/` is published).
+
+Navigation uses **Hotwire Turbo** (`@hotwired/turbo-rails` in the esbuild bundle). Flash messages use Bootstrap toasts (`flash_toasts.js`), not gritter.
+
+**Committed vs generated builds:** `app/assets/builds/application.js` (and `.map` / `.sources.sha256`) are committed so CI can verify the bundle matches sources. Compiled CSS (`application.css`, `software_records.css`) is **gitignored** — run `bin/rails dartsass:build` locally (or use `bin/setup` / `bin/dev`).
+
+### Local commands
+
+```bash
+nvm use
 bundle install
-bin/rails db:migrate
-bin/rails server
+bin/yarn install
+bin/setup                    # first-time: db:setup + asset builds
+bin/update                   # after pull: migrate + rebuild assets
+bin/dev                      # Foreman: Rails + esbuild watch + dartsass watch
+bin/rails javascript:build   # or: bin/yarn build
+bin/rails dartsass:build
+bin/rails assets:precompile  # JS + CSS builds + Propshaft digest (dev/production)
 ```
 
-Use Ruby **3.4.9** (see `.ruby-version`). Local developers may use **RVM or rbenv**; deploy hosts use rbenv (see Deployment below).
+After changing JS dependencies or source files, commit `package.json`, `yarn.lock`, and `app/assets/builds/application.js` (+ `.map` and `.sources.sha256` when present). Run `bin/yarn install` after pulling dependency changes.
 
-## Ruby version and System dependencies
+The **test** environment sets `SKIP_JS_BUILD` (`config/application.rb`); `assets:precompile` runs `dartsass:build` only and uses the committed JS bundle.
 
-Ruby 3.4.9
+### Deploy expectations
 
-Node.js 24.x (see `.nvmrc`; run `nvm install` in the project root)
+QA and production both use `RAILS_ENV=production` on deploy hosts. Capistrano’s `deploy:assets:precompile` (during `deploy:updated`) runs `scripts/assets_precompile.sh`:
 
-### JavaScript (esbuild)
+1. Source `scripts/check_node.sh` (nvm + `.nvmrc`, yarn via corepack when needed)
+2. `bundle exec rails assets:precompile` — `javascript:build`, `dartsass:build`, then Propshaft copies digested assets to `public/assets/`
 
-JavaScript is bundled with **esbuild** via `jsbundling-rails` (LIBAPPO1-101, LIBAPPO1-108). The entry point is `app/javascript/application.js`; `bin/rails javascript:build` (or `bin/yarn build`) writes `app/assets/builds/application.js` and source maps. Layouts load that bundle as a single deferred ES module (Turbo, Bootstrap, Chartkick, Active Storage, and app scripts).
+Production sets far-future `cache-control` headers for static files (`max-age=1.year`) because filenames include content hashes.
 
-`app/assets/builds/application.js` is **committed** so CI can verify the bundle matches sources (`yarn build` + git diff in CircleCI and GitHub Actions). The **test** environment skips esbuild during `assets:precompile` (`SKIP_JS_BUILD` in `config/application.rb`); **production deploy** runs `yarn install`, `yarn build`, and `dartsass:build` before Propshaft digests assets into `public/assets/`.
-
-After changing JS dependencies or source files locally:
-
-```bash
-nvm use
-yarn install
-bin/rails javascript:build
-```
-
-Commit `package.json`, `yarn.lock`, and `app/assets/builds/application.js` (+ `.map` and `.sources.sha256` when present). Run `yarn install` locally after pulling dependency changes.
-
-For local development with live rebuilds, use Foreman (runs Rails, esbuild watch, and Dart Sass watch). Run `nvm use` first so `bin/yarn` resolves Node 24:
-
-```bash
-nvm use
-bin/dev
-```
-
-**CI:** `yarn install --frozen-lockfile`, `yarn build`, and `bundle exec rails dartsass:build` run before RSpec.
-
-**Deploy:** Capistrano’s `deploy:assets:precompile` (during `deploy:updated`) runs `scripts/assets_precompile.sh`, which sources `scripts/check_node.sh` (nvm + `.nvmrc`, yarn via corepack when needed) then `bundle exec rails assets:precompile` (`javascript:build` + `dartsass:build`).
+**CI:** `bin/yarn install --frozen-lockfile`, `bin/yarn build`, and `bundle exec rails dartsass:build` run before RSpec (CircleCI and GitHub Actions).
 
 ### Bootstrap (npm + vendored assets)
 
 Bootstrap **5.x** is installed from npm (`package.json`). Dart Sass compiles the committed vendor SCSS under `app/assets/stylesheets/vendor/bootstrap/scss/`. JavaScript comes from the esbuild bundle (`import` from `node_modules` at build time).
 
-Deploy hosts do not run `yarn` for Bootstrap SCSS vendoring (use `bootstrap:vendor` locally). JavaScript is rebuilt on deploy via `assets:precompile`. After upgrading Bootstrap in `package.json`, refresh vendor SCSS and rebuild JS locally:
+Deploy hosts do not run `yarn` for Bootstrap SCSS vendoring (use `bootstrap:vendor` locally). After upgrading Bootstrap in `package.json`, refresh vendor SCSS and rebuild JS locally:
 
 ```bash
 nvm use
-yarn install
+bin/yarn install
 bundle exec rake bootstrap:vendor
 bin/rails javascript:build
+bin/rails dartsass:build
 ```
 
 Commit `package.json`, `yarn.lock`, `app/assets/builds/application.js`, and the updated files under `app/assets/stylesheets/vendor/bootstrap/`.
@@ -69,7 +97,7 @@ Commit `package.json`, `yarn.lock`, `app/assets/builds/application.js`, and the 
 The test suite uses RSpec, RuboCop, and Coveralls. From the project root:
 
 ```bash
-nvm use   # Node 24.x; required for yarn install if node_modules is missing
+nvm use   # Node 24.x; required for bin/yarn if node_modules is missing
 bundle exec rspec
 bundle exec rubocop
 ```
@@ -82,7 +110,9 @@ For Coveralls locally:
 coveralls report
 ```
 
-## Database creation
+## Database
+
+`bin/setup` runs `db:setup` (create, schema load, seed). To migrate only:
 
 ```bash
 bin/rails db:migrate RAILS_ENV=development
@@ -159,4 +189,4 @@ Automatic encryption and decryption on UI. But only encrypted on DB.
 
 * Graphs
 
-We use the chartkick gem to draw our graphs
+Dashboard charts use the **chartkick** gem (Ruby helpers) with **Chart.js** and **chartkick** npm packages bundled via esbuild (`app/javascript/application.js`).

--- a/spec/build/assets_precompile_spec.rb
+++ b/spec/build/assets_precompile_spec.rb
@@ -112,5 +112,22 @@ RSpec.describe 'assets pipeline' do
       expect(CompiledAssetExpectations.fingerprinted_asset?(public_assets, 'software_records', '.css')).to be(true)
       expect(Dir.glob(public_assets.join('**/*.scss'))).to be_empty
     end
+
+    it 'maps logical asset names to digest filenames in .manifest.json' do
+      QuietTestBuilds.precompile_assets!
+
+      manifest = JSON.parse(public_assets.join('.manifest.json').read)
+
+      expect(manifest.dig('application.js', 'digested_path')).to match(/\Aapplication-[a-f0-9]+\.js\z/)
+      expect(manifest.dig('application.css', 'digested_path')).to match(/\Aapplication-[a-f0-9]+\.css\z/)
+    end
+
+    it 'configures far-future cache-control for production deploys (QA and production)' do
+      production_rb = Rails.root.join('config/environments/production.rb').read
+
+      expect(production_rb).to include("config.public_file_server.headers = { 'cache-control' => \"public, max-age=\#{1.year.to_i}\" }")
+      expect(Rails.root.join('config/deploy/qa.rb').read).to include('set :rails_env, :production')
+      expect(Rails.root.join('config/deploy/production.rb').read).to include('set :rails_env, :production')
+    end
   end
 end

--- a/spec/requests/auth_assets_spec.rb
+++ b/spec/requests/auth_assets_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Authentication pages and assets', type: :request do
+  describe 'local email sign-in' do
+    around do |example|
+      original_shibboleth = Rails.configuration.x.auth.shibboleth_enabled
+      original_email = Rails.configuration.x.auth.allow_email_sign_in
+
+      Rails.configuration.x.auth.shibboleth_enabled = false
+      Rails.configuration.x.auth.allow_email_sign_in = true
+
+      example.run
+    ensure
+      Rails.configuration.x.auth.shibboleth_enabled = original_shibboleth
+      Rails.configuration.x.auth.allow_email_sign_in = original_email
+    end
+
+    it 'loads Propshaft application assets on the sign-in page' do
+      get new_user_session_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to match(%r{application[.-][a-f0-9]+\.css|/assets/application\.css})
+      expect(response.body).to match(%r{application[.-][a-f0-9]+\.js|/assets/application\.js})
+      expect(response.body).to include('type="module"')
+    end
+  end
+
+  describe 'Shibboleth mode' do
+    around do |example|
+      original_shibboleth = Rails.configuration.x.auth.shibboleth_enabled
+      Rails.configuration.x.auth.shibboleth_enabled = true
+
+      example.run
+    ensure
+      Rails.configuration.x.auth.shibboleth_enabled = original_shibboleth
+    end
+
+    it 'redirects sign-in to Shibboleth without rendering local login assets' do
+      get new_user_session_path
+
+      expect(response).to redirect_to('/Shibboleth.sso/Login?target=%2Fauth%2Fshibboleth&forceAuthn=1')
+    end
+  end
+end

--- a/spec/requests/flash_messages_spec.rb
+++ b/spec/requests/flash_messages_spec.rb
@@ -21,6 +21,28 @@ RSpec.describe 'Flash messages in responses', type: :request do
     expect(response.body).not_to include('gritter')
   end
 
+  it 'renders a notice toast after create' do
+    post statuses_path, params: { status: { title: 'New Status', status_type: 'Design' } }
+
+    follow_redirect!
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('flash-toast')
+    expect(response.body).to include('Status was successfully created')
+  end
+
+  it 'renders a notice toast after destroy' do
+    status = FactoryBot.create(:status, title: 'Retired', status_type: 'Design')
+
+    delete status_path(status)
+
+    follow_redirect!
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('flash-toast')
+    expect(response.body).to include('Status was successfully destroyed')
+  end
+
   it 'renders Bootstrap form error alerts for invalid submissions' do
     status = FactoryBot.create(:status, title: 'Active', status_type: 'Design')
 

--- a/spec/requests/software_records_index_spec.rb
+++ b/spec/requests/software_records_index_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Software records index filters', type: :request do
+  let(:admin) { FactoryBot.create(:admin) }
+
+  before { sign_in admin }
+
+  it 'renders filter UI wired to filtermanagement.js globals' do
+    get software_records_path
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include('onclick="handleRadio(this);"')
+    expect(response.body).to include('id="vendor-record-filter"')
+    expect(response.body).to include('id="software-type-filter"')
+    expect(response.body).to include("clearFiltersAndRedirect('software_records')")
+  end
+
+  it 'shows the vendor filter panel when filtering by vendor records' do
+    vendor = FactoryBot.create(:vendor_record)
+
+    get software_records_path, params: { filter_by: 'vendor_records', vendor_record_filter: vendor.id }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to match(/id="vendor-record-filter"[^>]*style="display:\s*block;?"/)
+    expect(response.body).to match(/id="software-type-filter"[^>]*style="display:\s*none"/)
+  end
+
+  it 'shows the software type filter panel when filtering by software types' do
+    software_type = FactoryBot.create(:software_type)
+
+    get software_records_path, params: { filter_by: 'software_types', software_type_filter: software_type.id }
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to match(/id="software-type-filter"[^>]*style="display:\s*block;?"/)
+    expect(response.body).to match(/id="vendor-record-filter"[^>]*style="display:\s*none"/)
+  end
+end

--- a/spec/support/esbuild_bundle_expectations.rb
+++ b/spec/support/esbuild_bundle_expectations.rb
@@ -11,6 +11,8 @@ module EsbuildBundleExpectations
     expect(content).to match(/turbo/i)
     expect(content).to match(/chartkick|Chartkick/i)
     expect(content).to include('js-add-multivalue')
+    expect(content).to include('handleRadio')
+    expect(content).to include('clearFiltersAndRedirect')
     expect(content).to match(/Dropdown|data-bs-toggle/i)
     expect(content).to match(/activestorage|ActiveStorage/i)
     expect(content).not_to include('@rails/ujs')


### PR DESCRIPTION
Document the Propshaft asset pipeline in README and add regression specs for charts, filters, flash toasts, auth assets, and production digest/cache expectations.

## Summary

Closes out the asset pipeline epic (LIBAPPO1-119) with README updates and targeted regression coverage after the Sprockets → Propshaft cutover.

- **README:** Documents compile-then-serve architecture (dartsass → `app/assets/builds/`, esbuild → `application.js`, Propshaft → `public/assets/`), correct quick start (`bin/setup` / `bin/dev`), committed JS vs gitignored CSS, Turbo/toasts, and deploy expectations (QA + production use `RAILS_ENV=production`, `scripts/assets_precompile.sh`).
- **Regression specs:** Propshaft-sensitive areas — dashboard charts (existing + bundle expectations), software record index filters (`filtermanagement.js` markup/globals), flash toasts on create/update/delete, sign-in page assets + Shibboleth redirect, manifest digests and production cache-control config.

## Post-Propshaft QA checklist

| Area | Automated coverage |
|------|-------------------|
| Dashboard charts (Chartkick) | `spec/requests/front_spec.rb`, `EsbuildBundleExpectations` |
| Software record multi-value fields | `spec/features/software_records/multi_value_spec.rb` |
| Flash toasts (create / update / delete) | `spec/requests/flash_messages_spec.rb` |
| Shibboleth / login + assets | `spec/requests/auth_assets_spec.rb`, existing Shibboleth controller specs |
| Software records index filters | `spec/requests/software_records_index_spec.rb`, bundle includes `handleRadio` / `clearFiltersAndRedirect` |
| Asset digests + cache headers | `spec/build/assets_precompile_spec.rb` (`.manifest.json` digested paths, production `cache-control`, QA/prod `rails_env`) |

Manual smoke on QA after deploy: dashboard charts render, index filter panels toggle, flash toasts on CRUD, SSO login unchanged.

## Test plan

- [x] `bundle exec rubocop`
- [x] `bundle exec rspec` (650 examples, 0 failures)
- [ ] Deploy to QA and run manual smoke checklist above