### PR TITLE
Fix production deploy asset precompile and Yarn 4 activation.

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -5,14 +5,17 @@
 set :rails_env, :production
 # Colon-separated groups; required by capistrano-bundler 2.x / Bundler 2.
 set :bundle_without, %w[development test].join(':')
-set :branch, 'main'
+# Production currently tracks qa until v3.1.0 is promoted to main.
+set :branch, 'qa'
 set :default_env, path: '$PATH:/usr/local/bin'
 # Shared across releases; written by capistrano-bundler's bundler:config.
 set :bundle_path, -> { shared_path.join('vendor/bundle') }
 append :linked_dirs, 'tmp', 'log'
 ask(:username, nil)
 ask(:password, nil, echo: false)
-server 'libapps.libraries.uc.edu', user: fetch(:username), password: fetch(:password), port: 22
+# Roles required for deploy:assets:precompile (:web) and db:migrate (:db); without them Capistrano skips both.
+server 'libapps.libraries.uc.edu', user: fetch(:username), password: fetch(:password),
+                                   port: 22, roles: %i[web app db]
 ask(:value, 'Have you submitted and received an approved Change Management Request? (Y)')
 if fetch(:value) != 'Y'
   puts "\nDeploy cancelled!"

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -6,7 +6,7 @@ set :rails_env, :production
 # Colon-separated groups; required by capistrano-bundler 2.x / Bundler 2.
 set :bundle_without, %w[development test].join(':')
 # Production currently tracks qa until v3.1.0 is promoted to main.
-set :branch, 'qa'
+set :branch, 'main'
 set :default_env, path: '$PATH:/usr/local/bin'
 # Shared across releases; written by capistrano-bundler's bundler:config.
 set :bundle_path, -> { shared_path.join('vendor/bundle') }

--- a/scripts/assets_precompile.sh
+++ b/scripts/assets_precompile.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Run on deploy via Capistrano (execute :bash, 'scripts/assets_precompile.sh') so SSHKit
-# applies within release_path and RAILS_ENV. Sources check_node.sh (Node 26 + Yarn 4),
-# then runs assets:precompile which builds JavaScript and CSS on the deploy host.
+# applies within release_path and RAILS_ENV. Activates Node 26 (check_node.sh) and Yarn 4
+# (corepack_yarn.sh) before assets:precompile builds JavaScript and CSS on the deploy host.
 set -euo pipefail
 
 APP_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -10,4 +10,7 @@ cd "$APP_ROOT"
 [ -f Gemfile ] || { echo "Not in application root: ${APP_ROOT}" >&2; exit 1; }
 
 source scripts/check_node.sh
+# shellcheck source=scripts/corepack_yarn.sh
+source scripts/corepack_yarn.sh
+setup_corepack_yarn
 exec bundle exec rails assets:precompile

--- a/spec/lib/capistrano_assets_spec.rb
+++ b/spec/lib/capistrano_assets_spec.rb
@@ -13,8 +13,16 @@ RSpec.describe 'Capistrano asset deploy tasks' do
     expect(assets_rake).to include("execute :bash, 'scripts/assets_precompile.sh'")
     expect(assets_rake).to include('release_roles(fetch(:assets_roles))')
     expect(assets_precompile_sh).to include('source scripts/check_node.sh')
+    expect(assets_precompile_sh).to include('source scripts/corepack_yarn.sh')
+    expect(assets_precompile_sh).to include('setup_corepack_yarn')
     expect(assets_precompile_sh).to include('bundle exec rails assets:precompile')
     expect(assets_precompile_sh).to include('[ -f Gemfile ]')
+  end
+
+  it 'assigns Capistrano roles on production so assets and migrations run' do
+    production_rb = Rails.root.join('config/deploy/production.rb').read
+
+    expect(production_rb).to include('roles: %i[web app db]')
   end
 
   it 'requires check_node.sh to be sourced and activates nvm Node for yarn' do


### PR DESCRIPTION
Assign Capistrano roles on the production server so assets and migrations run, and activate Corepack Yarn before assets:precompile on deploy hosts.